### PR TITLE
Finalize install/uninstall logic with 13 tools - E2E validation (Ubuntu 22/24 + Amazon Linux 2023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,25 @@ The Arm Linux Migration Tools package simplifies the process of migrating applic
 ## System Requirements
 
 - **Architecture**: Arm (aarch64)
-- **Operating System**: Linux (Ubuntu 22.04/24.04 recommended)
-- **Dependencies**: Python 3, build tools, and package manager (apt/yum/dnf)
+- **Operating System**: Linux (Ubuntu 22.04/24.04 recommended), Amazon Linux 2023
+- **Dependencies**: 
+  - Python 3 (≥3.10 recommended; required for running **Porting Advisor**)
+  - Build tools (e.g. gcc, g++, make) 
+  - Package manager (apt/yum/dnf)
+
+## Tool Notes
+
+- **Skopeo**:  
+  - On Ubuntu, installed natively via `apt`.  
+  - On Amazon Linux 2023, Skopeo is **not available in default repos**.  
+    - You can run it via the provided **container wrapper** (`skopeo-container`)  
+    - Or build it manually from source / use GitHub release binaries.  
+
+- **Porting Advisor**:  
+  - Installs successfully on both Ubuntu and Amazon Linux.  
+  - Requires **Python ≥3.10** to run.  
+  - Ubuntu 22.04/24.04 meet this requirement.  
+  - Amazon Linux 2023 defaults to Python 3.9 → binary installs but won’t run unless Python is upgraded.
 
 ## Quick Start
 
@@ -64,12 +81,21 @@ You can uninstall by running:
 ```bash
 /opt/arm-migration-tools/scripts/uninstall.sh
 ```
+**Note** 
+The uninstall script:
+- Removes `/opt/arm-migration-tools`  
+- Removes wrappers in `/usr/local/bin`  
+- Removes system packages (perf, llvm-mca, skopeo) where installed  
 
 You can also download and run the uninstall:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/arm/arm-linux-migration-tools/main/scripts/uninstall.sh | bash
 ```
+
+**Note:** Both install and uninstall scripts are **idempotent**.  
+- Running `install.sh` again will detect already-installed tools and skip re-installation.  
+- Running `uninstall.sh` again will simply confirm that everything is already removed.
 
 This package includes 13 essential migration and analysis tools:
 

--- a/scripts/build_processwatch.sh
+++ b/scripts/build_processwatch.sh
@@ -1,19 +1,62 @@
 #!/bin/bash
-# Build script for Process Watch
-set -e
+# Build script for Process Watch (Ubuntu, Amazon Linux 2/2023)
+set -euo pipefail
 
-# Install build dependencies (for Ubuntu)
-sudo apt-get update
-sudo apt-get install -y libelf-dev cmake clang llvm llvm-dev
+INSTALL_PREFIX="/opt/arm-migration-tools"
+SRC_DIR="$INSTALL_PREFIX/processwatch"
 
-# Clone the repo if not present
-if [ ! -d processwatch ]; then
-  git clone --recursive https://github.com/intel/processwatch.git
+detect_pkg_mgr() {
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "apt"
+  elif command -v dnf >/dev/null 2>&1; then
+    echo "dnf"
+  elif command -v yum >/dev/null 2>&1; then
+    echo "yum"
+  else
+    echo "[ERROR] No supported package manager found (need apt, dnf, or yum)." >&2
+    exit 1
+  fi
+}
+
+install_deps() {
+  local pmgr
+  pmgr="$(detect_pkg_mgr)"
+  case "$pmgr" in
+    apt)
+      sudo apt-get update -y
+      sudo apt-get install -y libelf-dev cmake clang llvm llvm-dev git make
+      ;;
+    dnf)
+      sudo dnf -y install elfutils-libelf-devel cmake clang llvm llvm-devel git make
+      ;;
+    yum) # Amazon Linux 2
+      sudo yum -y install elfutils-libelf-devel cmake clang llvm llvm-devel git make
+      ;;
+  esac
+}
+
+install_deps
+
+sudo mkdir -p "$INSTALL_PREFIX"
+cd "$INSTALL_PREFIX"
+
+# Clone if missing
+if [ ! -d "$SRC_DIR" ]; then
+  git clone --recursive https://github.com/intel/processwatch.git "$SRC_DIR"
+else
+  # Refresh source if already present
+  git -C "$SRC_DIR" fetch --all --tags || true
+  git -C "$SRC_DIR" submodule update --init --recursive || true
 fi
 
-# Build the tool
-cd processwatch
+# Build
+cd "$SRC_DIR"
 ./build.sh
-cd ..
 
-echo "[INFO] Process Watch build complete."
+# Verify binary
+if [ ! -x "$SRC_DIR/processwatch" ]; then
+  echo "[ERROR] Process Watch build did not produce a binary at $SRC_DIR/processwatch" >&2
+  exit 1
+fi
+
+echo "[INFO] Process Watch build complete: $SRC_DIR/processwatch"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,14 +218,11 @@ if [ -f "$SCRIPTS_DIR/install_kubearchinspect.sh" ]; then
   fi
 fi
 
-# Install perf
+# ---- Perf: always ensure it's installed & wired correctly ----
 if [ -f "$SCRIPTS_DIR/install_perf.sh" ]; then
-  if command -v perf >/dev/null 2>&1; then
-    echo "[INFO] Perf already installed, skipping."
-  else
-    echo "[INFO] Installing Perf..."
-    bash "$SCRIPTS_DIR/install_perf.sh"
-  fi
+  echo "[INFO] Ensuring Perf is installed and wired..."
+  # Tune kernel.perf_event_paranoid unless explicitly disabled by caller
+  PERF_TUNE_SYSCTL="${PERF_TUNE_SYSCTL:-1}" bash "$SCRIPTS_DIR/install_perf.sh" || true
 fi
 
 # Install MCA (llvm-mca)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,17 @@
 # Supports both local installation (with tarball) and remote installation (via curl)
 set -e
 
+# Require root; auto-escalate if possible
+if [ "$EUID" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    exec sudo -E -- "$0" "$@"
+  else
+    echo "[ERROR] This installer must be run as root; 'sudo' not found." >&2
+    echo "        Switch to root (e.g., 'su -') and re-run this script." >&2
+    exit 1
+  fi
+fi
+
 # Check for Arm Linux (aarch64)
 ARCH=$(uname -m)
 if [ "$ARCH" != "aarch64" ]; then
@@ -10,10 +21,68 @@ if [ "$ARCH" != "aarch64" ]; then
   exit 1
 fi
 
+LOCKFILE="/tmp/arm-migration-tools.lock"
+exec 200>"$LOCKFILE"
+flock -n 200 || {
+  echo "[ERROR] Another install.sh is already running. Exiting."
+  exit 1
+}
+# ------------------------------
+# Cross-distro dependency install
+# Supports: Ubuntu (apt), Amazon Linux 2023 (dnf), Amazon Linux 2 (yum)
+# ------------------------------
+detect_pkg_mgr() {
+  if command -v apt-get >/dev/null 2>&1; then
+    PKG_MGR="apt"
+  elif command -v dnf >/dev/null 2>&1; then
+    PKG_MGR="dnf"
+  elif command -v yum >/dev/null 2>&1; then
+    PKG_MGR="yum"
+  else
+    echo "[ERROR] Supported package manager not found (need apt, dnf, or yum)." >&2
+    exit 1
+  fi
+}
+
+ensure_deps() {
+  detect_pkg_mgr
+
+  COMMON_PKGS=(curl wget git python3 python3-pip)
+
+  case "$PKG_MGR" in
+    apt)
+      APT_PKGS=(build-essential python3-venv python-is-python3)
+      echo "[INFO] Installing prerequisites via apt..."
+      sudo apt-get update -y
+      sudo apt-get install -y "${COMMON_PKGS[@]}" "${APT_PKGS[@]}"
+      ;;
+    dnf|yum)
+      # gcc/g++/make ≈ build-essential
+      YUM_PKGS=(gcc gcc-c++ make)
+      echo "[INFO] Installing prerequisites via $PKG_MGR..."
+      # If curl-minimal already exists, don't try to install curl
+      if rpm -q curl-minimal >/dev/null 2>&1; then
+        echo "[INFO] curl-minimal present, skipping curl package."
+        COMMON_PKGS=(wget git python3 python3-pip)
+      fi
+
+      sudo $PKG_MGR -y install "${COMMON_PKGS[@]}" "${YUM_PKGS[@]}"
+      sudo $PKG_MGR -y install python3-venv 2>/dev/null || true
+      sudo $PKG_MGR -y install python3-virtualenv 2>/dev/null || true
+      ;;
+  esac
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "[ERROR] python3 not found after package install." >&2
+    exit 1
+  fi
+}
+
 INSTALL_PREFIX="/opt/arm-migration-tools"
 GITHUB_REPO="arm/arm-linux-migration-tools"
+STAMP_FILE="$INSTALL_PREFIX/.installed_version"
 
-sudo apt-get install -y build-essential python3 python3-pip python3-venv python-is-python3 curl wget git
+ensure_deps
 
 # Detect if this is a remote installation (no local tarball files)
 REMOTE_INSTALL=false
@@ -22,50 +91,57 @@ if [ ! -f "$(dirname "$0")/../README.md" ] && [ -z "$(ls arm-migration-tools-v*.
 fi
 
 # Handle remote installation
+
 if [ "$REMOTE_INSTALL" = true ]; then
   echo "[INFO] Remote installation detected. Downloading latest release..."
-  
+
   # Check for required tools
   if ! command -v curl >/dev/null 2>&1; then
     echo "[ERROR] curl is required for remote installation but not found." >&2
     exit 1
   fi
-  
+
   # Fetch latest release information
   LATEST_RELEASE_URL="https://api.github.com/repos/$GITHUB_REPO/releases/latest"
   echo "[INFO] Fetching latest release information..."
-  
+
   LATEST_TAG=$(curl -s "$LATEST_RELEASE_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | tr -d 'v')
   if [ -z "$LATEST_TAG" ]; then
     echo "[ERROR] Failed to fetch latest release tag" >&2
     exit 1
   fi
-  
+
   VERSION="$LATEST_TAG"
-  DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$LATEST_TAG/arm-migration-tools-v$LATEST_TAG.tar.gz"
-  echo "[INFO] Downloading version v$LATEST_TAG from $DOWNLOAD_URL..."
-  
-  # Create temporary directory and download
-  TEMP_DIR=$(mktemp -d)
-  cd "$TEMP_DIR"
-  
-  if ! curl -L -f -o "arm-migration-tools.tar.gz" "$DOWNLOAD_URL"; then
-    echo "[ERROR] Failed to download release tarball" >&2
-    exit 1
+  if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$VERSION" ]; then
+    echo "[INFO] arm-migration-tools v$VERSION already installed at $INSTALL_PREFIX, skipping download/extract."
+    SCRIPTS_DIR="$INSTALL_PREFIX/scripts"
+  else
+    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$LATEST_TAG/arm-migration-tools-v$LATEST_TAG.tar.gz"
+    echo "[INFO] Downloading version v$LATEST_TAG from $DOWNLOAD_URL..."
+
+    # Create temporary directory and download
+    TEMP_DIR=$(mktemp -d)
+    cd "$TEMP_DIR"
+
+    if ! curl -L -f -o "arm-migration-tools.tar.gz" "$DOWNLOAD_URL"; then
+      echo "[ERROR] Failed to download release tarball" >&2
+      exit 1
+    fi
+
+    # Extract to install prefix
+    echo "[INFO] Extracting to $INSTALL_PREFIX..."
+    sudo mkdir -p "$INSTALL_PREFIX"
+    sudo tar xzf "arm-migration-tools.tar.gz" -C "$INSTALL_PREFIX"
+    echo "$VERSION" | sudo tee "$STAMP_FILE" >/dev/null   # record the installed version
+
+    # Change to the extracted scripts directory
+    SCRIPTS_DIR="$INSTALL_PREFIX/scripts"
+
+    # Clean up temp directory
+    cd /
+    rm -rf "$TEMP_DIR"
   fi
-  
-  # Extract to install prefix
-  echo "[INFO] Extracting to $INSTALL_PREFIX..."
-  sudo mkdir -p "$INSTALL_PREFIX"
-  sudo tar xzf "arm-migration-tools.tar.gz" -C "$INSTALL_PREFIX"
-  
-  # Change to the extracted scripts directory
-  SCRIPTS_DIR="$INSTALL_PREFIX/scripts"
-  
-  # Clean up temp directory
-  cd /
-  rm -rf "$TEMP_DIR"
-  
+
 else
   # Handle local installation
   echo "[INFO] Local installation detected."
@@ -88,10 +164,15 @@ else
     exit 1
   fi
 
-  echo "[INFO] Extracting $TAR_FILE to $INSTALL_PREFIX..."
-  sudo mkdir -p "$INSTALL_PREFIX"
-  sudo tar xzf "$TAR_FILE" -C "$INSTALL_PREFIX"
-  
+  if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$VERSION" ]; then
+    echo "[INFO] arm-migration-tools v$VERSION already installed at $INSTALL_PREFIX, skipping extract."
+  else
+    echo "[INFO] Extracting $TAR_FILE to $INSTALL_PREFIX..."
+    sudo mkdir -p "$INSTALL_PREFIX"
+    sudo tar xzf "$TAR_FILE" -C "$INSTALL_PREFIX"
+    echo "$VERSION" | sudo tee "$STAMP_FILE" >/dev/null
+  fi
+
   # Use relative path for local installation
   SCRIPTS_DIR="$(dirname "$0")"
 fi
@@ -110,86 +191,141 @@ echo "[INFO] Installing individual tools..."
 
 # Install sysreport
 if [ -f "$SCRIPTS_DIR/install_sysreport.sh" ]; then
-  echo "[INFO] Installing Sysreport..."
-  bash "$SCRIPTS_DIR/install_sysreport.sh"
+  if command -v sysreport >/dev/null 2>&1; then
+    echo "[INFO] Sysreport already installed, skipping."
+  else
+    echo "[INFO] Installing Sysreport..."
+    bash "$SCRIPTS_DIR/install_sysreport.sh"
+  fi
 fi
-
 # Install skopeo
 if [ -f "$SCRIPTS_DIR/install_skopeo.sh" ]; then
-  echo "[INFO] Installing Skopeo..."
-  bash "$SCRIPTS_DIR/install_skopeo.sh"
+  if command -v skopeo >/dev/null 2>&1; then
+    echo "[INFO] Skopeo already installed, skipping."
+  else
+    echo "[INFO] Installing Skopeo..."
+    bash "$SCRIPTS_DIR/install_skopeo.sh"
+  fi
 fi
 
 # Install kubearchinspect
 if [ -f "$SCRIPTS_DIR/install_kubearchinspect.sh" ]; then
-  echo "[INFO] Installing KubeArchInspect..."
-  bash "$SCRIPTS_DIR/install_kubearchinspect.sh"
+  if command -v kubearchinspect >/dev/null 2>&1; then
+    echo "[INFO] KubeArchInspect already installed, skipping."
+  else
+    echo "[INFO] Installing KubeArchInspect..."
+    bash "$SCRIPTS_DIR/install_kubearchinspect.sh"
+  fi
 fi
 
 # Install perf
 if [ -f "$SCRIPTS_DIR/install_perf.sh" ]; then
-  echo "[INFO] Installing Perf..."
-  bash "$SCRIPTS_DIR/install_perf.sh"
+  if command -v perf >/dev/null 2>&1; then
+    echo "[INFO] Perf already installed, skipping."
+  else
+    echo "[INFO] Installing Perf..."
+    bash "$SCRIPTS_DIR/install_perf.sh"
+  fi
 fi
 
 # Install MCA (llvm-mca)
 if [ -f "$SCRIPTS_DIR/install_mca.sh" ]; then
-  echo "[INFO] Installing MCA..."
-  bash "$SCRIPTS_DIR/install_mca.sh"
+  if command -v llvm-mca >/dev/null 2>&1; then
+    echo "[INFO] llvm-mca already installed, skipping."
+  else
+    echo "[INFO] Installing MCA..."
+    bash "$SCRIPTS_DIR/install_mca.sh"
+  fi
 fi
 
 # Install Aperf
 if [ -f "$SCRIPTS_DIR/install_aperf.sh" ]; then
-  echo "[INFO] Installing Aperf..."
-  bash "$SCRIPTS_DIR/install_aperf.sh"
+  if command -v aperf >/dev/null 2>&1; then
+    echo "[INFO] Aperf already installed, skipping."
+  else
+    echo "[INFO] Installing Aperf..."
+    bash "$SCRIPTS_DIR/install_aperf.sh"
+  fi
 fi
 
 # Install BOLT
 if [ -f "$SCRIPTS_DIR/install_bolt.sh" ]; then
-  echo "[INFO] Installing BOLT..."
-  bash "$SCRIPTS_DIR/install_bolt.sh"
+  if command -v llvm-bolt >/dev/null 2>&1 && command -v perf2bolt >/dev/null 2>&1; then
+    echo "[INFO] BOLT already installed, skipping."
+  else
+    echo "[INFO] Installing BOLT..."
+    bash "$SCRIPTS_DIR/install_bolt.sh"
+  fi
 fi
 
 # Install Process Watch
 if [ -f "$SCRIPTS_DIR/install_processwatch.sh" ]; then
-  echo "[INFO] Installing Process Watch..."
-  bash "$SCRIPTS_DIR/install_processwatch.sh"
+  if command -v processwatch >/dev/null 2>&1; then
+    echo "[INFO] Process Watch already installed, skipping."
+  else
+    echo "[INFO] Installing Process Watch..."
+    bash "$SCRIPTS_DIR/install_processwatch.sh"
+  fi
 fi
 
 # Install PAPI
 if [ -f "$SCRIPTS_DIR/install_papi.sh" ]; then
-  echo "[INFO] Installing PAPI..."
-  bash "$SCRIPTS_DIR/install_papi.sh"
+  if command -v papi_avail >/dev/null 2>&1; then
+    echo "[INFO] PAPI already installed, skipping."
+  else
+    echo "[INFO] Installing PAPI..."
+    bash "$SCRIPTS_DIR/install_papi.sh"
+  fi
 fi
 
 # Install Migrate Ease
 if [ -f "$SCRIPTS_DIR/install_migrate_ease.sh" ]; then
-  echo "[INFO] Installing Migrate Ease..."
-  bash "$SCRIPTS_DIR/install_migrate_ease.sh"
+  if python3 -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('migrate_ease') else 1)" 2>/dev/null; then
+    echo "[INFO] Migrate Ease (Python pkg) already installed, skipping."
+  else
+    echo "[INFO] Installing Migrate Ease..."
+    bash "$SCRIPTS_DIR/install_migrate_ease.sh"
+  fi
 fi
 
 # Install Migrate Ease wrappers
 if [ -f "$SCRIPTS_DIR/install_migrate_ease_wrappers.sh" ]; then
-  echo "[INFO] Installing Migrate Ease wrappers..."
-  bash "$SCRIPTS_DIR/install_migrate_ease_wrappers.sh"
+  if command -v migrate-ease-cpp >/dev/null 2>&1; then
+    echo "[INFO] Migrate Ease wrappers already installed, skipping."
+  else
+    echo "[INFO] Installing Migrate Ease wrappers..."
+    bash "$SCRIPTS_DIR/install_migrate_ease_wrappers.sh"
+  fi
 fi
 
 # Install check-image wrapper
 if [ -f "$SCRIPTS_DIR/install_check_image.sh" ]; then
-  echo "[INFO] Installing Check Image..."
-  bash "$SCRIPTS_DIR/install_check_image.sh"
+  if command -v check-image >/dev/null 2>&1; then
+    echo "[INFO] Check Image already installed, skipping."
+  else
+    echo "[INFO] Installing Check Image..."
+    bash "$SCRIPTS_DIR/install_check_image.sh"
+  fi
 fi
 
 # Install porting-advisor wrapper
 if [ -f "$SCRIPTS_DIR/install_porting_advisor.sh" ]; then
-  echo "[INFO] Installing Porting Advisor..."
-  bash "$SCRIPTS_DIR/install_porting_advisor.sh"
+  if command -v porting-advisor >/dev/null 2>&1; then
+    echo "[INFO] Porting Advisor already installed, skipping."
+  else
+    echo "[INFO] Installing Porting Advisor..."
+    bash "$SCRIPTS_DIR/install_porting_advisor.sh"
+  fi
 fi
 
 # Install topdown-tool wrapper
 if [ -f "$SCRIPTS_DIR/install_topdown_tool.sh" ]; then
-  echo "[INFO] Installing Topdown Tool..."
-  bash "$SCRIPTS_DIR/install_topdown_tool.sh"
+  if command -v topdown-tool >/dev/null 2>&1; then
+    echo "[INFO] Topdown Tool already installed, skipping."
+  else
+    echo "[INFO] Installing Topdown Tool..."
+    bash "$SCRIPTS_DIR/install_topdown_tool.sh"
+  fi
 fi
 
 # Set up Python venv and install requirements
@@ -201,17 +337,42 @@ if [ -z "$PYTHON3" ]; then
 fi
 if [ ! -d "$VENV_PATH" ]; then
   echo "[INFO] Creating Python venv at $VENV_PATH..."
-  sudo "$PYTHON3" -m venv "$VENV_PATH"
-fi
-# Upgrade pip and install requirements
-sudo "$VENV_PATH/bin/pip" install --upgrade pip
-if [ -f "$INSTALL_PREFIX/requirements.txt" ]; then
-  sudo "$VENV_PATH/bin/pip" install -r "$INSTALL_PREFIX/requirements.txt"
+  if ! "$PYTHON3" -m venv "$VENV_PATH" 2>/dev/null; then
+    echo "[INFO] python -m venv unavailable; falling back to virtualenv..."
+    "$PYTHON3" -m pip install --upgrade pip virtualenv
+    "$PYTHON3" -m virtualenv "$VENV_PATH"
+  fi
 fi
 
-# Install Topdown Tool in editable mode in the venv
+
+# Upgrade pip and install requirements
+sudo "$VENV_PATH/bin/pip" install --upgrade pip
+
+# Install requirements only if requirements.txt changed
+REQ_FILE="$INSTALL_PREFIX/requirements.txt"
+REQ_HASH_FILE="$VENV_PATH/.reqs_hash"
+
+if [ -f "$REQ_FILE" ]; then
+  NEW_HASH=$(sha256sum "$REQ_FILE" | awk '{print $1}')
+  OLD_HASH=$(cat "$REQ_HASH_FILE" 2>/dev/null || true)
+
+  if [ "$NEW_HASH" != "$OLD_HASH" ]; then
+    echo "[INFO] Installing/Updating Python requirements..."
+    sudo "$VENV_PATH/bin/pip" install -r "$REQ_FILE"
+    echo "$NEW_HASH" | sudo tee "$REQ_HASH_FILE" >/dev/null
+  else
+    echo "[INFO] Python requirements already up-to-date, skipping."
+  fi
+fi
+
+# Install Topdown Tool in editable mode in the venv (idempotent)
 if [ -d "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool" ]; then
-  sudo "$VENV_PATH/bin/pip" install -e "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool"
+  if "$VENV_PATH/bin/python" -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('topdown_tool') else 1)" 2>/dev/null; then
+    echo "[INFO] topdown_tool already importable in venv, skipping -e install."
+  else
+    echo "[INFO] Installing topdown_tool into venv (-e)..."
+    sudo "$VENV_PATH/bin/pip" install -e "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool"
+  fi
 fi
 
 # Record tool versions in a single file (after install)
@@ -258,3 +419,41 @@ cat <<EOM
   source /opt/arm-migration-tools/venv/bin/activate
 Or use the provided wrappers in /usr/local/bin for each tool (recommended).
 EOM
+
+
+# ---- Compact install summary ----
+echo "[SUMMARY]"
+
+summary_check() {
+  local name="$1" cmd="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    case "$cmd" in
+      kubearchinspect)
+        echo "$name: OK (Check how ready your Kubernetes cluster is to run on Arm.)" ;;
+      porting-advisor)
+        if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)'; then
+          echo "$name: OK ($("$cmd" --version 2>&1 | head -n1))"
+        else
+          echo "$name: INSTALLED (Python ≥3.10 required to run)"
+        fi ;;
+      *)
+        echo "$name: OK ($("$cmd" --version 2>&1 | head -n1 || $cmd --help 2>&1 | head -n1))" ;;
+    esac
+  else
+    echo "$name: SKIPPED"
+  fi
+}
+
+summary_check "sysreport" sysreport
+summary_check "kubearchinspect" kubearchinspect
+summary_check "migrate-ease-cpp" migrate-ease-cpp
+summary_check "aperf" aperf
+summary_check "llvm-bolt" llvm-bolt
+summary_check "perf" perf
+summary_check "llvm-mca" llvm-mca
+summary_check "papi" papi_avail
+summary_check "processwatch" processwatch
+summary_check "check-image" check-image
+summary_check "porting-advisor" porting-advisor
+summary_check "skopeo" skopeo
+summary_check "topdown-tool" topdown-tool

--- a/scripts/install_mca.sh
+++ b/scripts/install_mca.sh
@@ -1,23 +1,55 @@
 #!/bin/bash
 # Install MCA (llvm-mca) using the system package manager
+# Supports: Ubuntu/Debian, Amazon Linux 2023, Fedora/RHEL/CentOS
 set -e
+
+# Helper: check if llvm-mca is actually present
+have_mca() { command -v llvm-mca >/dev/null 2>&1; }
 
 if [ -f /etc/os-release ]; then
     . /etc/os-release
+
     if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
         echo "[INFO] Installing llvm-mca with apt..."
         sudo apt-get update
         sudo apt-get install -y llvm
+
+        if have_mca; then
+            echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."
+        else
+            echo "[WARN] llvm installed but 'llvm-mca' not found on PATH."
+            echo "[WARN] On some Ubuntu versions llvm-mca is in versioned packages (e.g. llvm-14)."
+            echo "[WARN] Try: sudo apt-get install -y 'llvm-*-tools'"
+        fi
+        exit 0
+
+    elif [[ $ID == "amzn" ]]; then
+        echo "[INFO] Installing llvm on Amazon Linux 2023..."
+        # AL2023 uses dnf
+        sudo dnf -y install llvm || true
+        sudo dnf -y install llvm-tools || true
+        sudo dnf -y install clang || true
+
+        if have_mca; then
+            echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."
+        else
+            echo "[WARN] 'llvm-mca' not available in Amazon Linux 2023 repos."
+            echo "[WARN] Skipping llvm-mca. You can install it manually (from LLVM releases or source)."
+        fi
+        exit 0
+
     elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
         echo "[INFO] Installing llvm-mca with dnf/yum..."
-        sudo dnf install -y llvm || sudo yum install -y llvm
+        sudo dnf -y install llvm || sudo yum -y install llvm
+        sudo dnf -y install llvm-tools || true
+        echo "[INFO] MCA (llvm-mca) installation attempt finished. Run 'llvm-mca --help' to test."
+        exit 0
+
     else
         echo "[ERROR] Unsupported OS: $ID. Please install llvm-mca manually."
-        exit 1
+        exit 0
     fi
 else
     echo "[ERROR] Cannot detect OS. Please install llvm-mca manually."
-    exit 1
+    exit 0
 fi
-
-echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."

--- a/scripts/install_perf.sh
+++ b/scripts/install_perf.sh
@@ -5,15 +5,57 @@ set -e
 install_perf() {
     if [ -f /etc/os-release ]; then
         . /etc/os-release
+
         if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
             echo "[INFO] Installing Perf with apt..."
-            if sudo apt-get update && sudo apt-get install -y linux-tools-generic linux-tools-$(uname -r); then
-                echo "[INFO] Perf installation complete. Run 'perf --help' to test."
+            KVER="$(uname -r)"
+            if sudo apt-get update && sudo apt-get install -y linux-tools-common linux-tools-generic "linux-tools-${KVER}"; then
+                # cloud-tools is optional; ignore failure if missing
+                sudo apt-get install -y "linux-cloud-tools-${KVER}" || true
+
+                # If the kernel-matched perf helper doesn't exist, fall back to the newest available
+                if [ ! -x "/usr/lib/linux-tools/${KVER}/perf" ]; then
+                    echo "[WARN] No perf helper for ${KVER}, trying fallback..."
+                    FALLBACK=$(ls -1 /usr/lib/linux-tools-*/perf 2>/dev/null | sort -V | tail -n1 || true)
+                    if [ -n "$FALLBACK" ]; then
+                        sudo mkdir -p "/usr/lib/linux-tools/${KVER}"
+                        sudo ln -sf "$FALLBACK" "/usr/lib/linux-tools/${KVER}/perf"
+                        FBVER=$(basename "$(dirname "$FALLBACK")" | sed 's/^linux-tools-//')
+                        echo "[INFO] Symlinked fallback perf from kernel ${FBVER} -> expected ${KVER}"
+                        echo "[INFO] Note: software events will work; some hardware events may not with a mismatched helper."
+                    else
+                        echo "[WARN] No fallback perf found on system."
+                    fi
+                fi
+
+                echo "[INFO] Perf installation complete. Run 'perf --version' to test."
                 return 0
             else
-                echo "[WARN] Failed to install Perf packages. This may be due to missing kernel-specific packages (common in Docker containers)."
+                echo "[WARN] Failed to install Perf packages via apt."
                 return 1
             fi
+
+        elif [[ $ID == "amzn" ]]; then
+            echo "[INFO] Installing Perf on Amazon Linux..."
+            # AL2023 uses dnf; AL2 uses yum. Package name is 'perf'.
+            if command -v dnf >/dev/null 2>&1; then
+                if sudo dnf install -y perf; then
+                    echo "[INFO] Perf installation complete. Run 'perf --version' to test."
+                    return 0
+                else
+                    echo "[WARN] 'dnf install perf' failed on Amazon Linux."
+                    return 1
+                fi
+            else
+                if sudo yum install -y perf; then
+                    echo "[INFO] Perf installation complete. Run 'perf --version' to test."
+                    return 0
+                else
+                    echo "[WARN] 'yum install perf' failed on Amazon Linux."
+                    return 1
+                fi
+            fi
+
         elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
             echo "[INFO] Installing Perf with dnf/yum..."
             if sudo dnf install -y perf 2>/dev/null || sudo yum install -y perf 2>/dev/null; then
@@ -23,6 +65,7 @@ install_perf() {
                 echo "[WARN] Failed to install Perf package."
                 return 1
             fi
+
         else
             echo "[WARN] Unsupported OS: $ID. Skipping Perf installation."
             return 1

--- a/scripts/install_skopeo.sh
+++ b/scripts/install_skopeo.sh
@@ -9,11 +9,18 @@ if [ -f /etc/os-release ]; then
         echo "[INFO] Installing Skopeo with apt..."
         sudo apt-get update
         sudo apt-get install -y skopeo
+
+    elif [[ $ID == "amzn" ]]; then
+        # Temporary decision: skip Skopeo on Amazon Linux; continue without failing
+        echo "[WARN] Amazon Linux detected (amzn). Skipping Skopeo install for now."
+        exit 0
+
     elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
         echo "[INFO] Installing Skopeo with yum..."
         sudo yum install -y skopeo || sudo dnf install -y skopeo
+
     else
-        echo "[ERROR] Unsupported OS: $ID. Please install Skopeo manually."
+        echo "[WARN] Unsupported OS: $ID. Please install Skopeo manually."
         exit 1
     fi
 else

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Uninstall all Arm migration tools
+# - Removes /opt/arm-migration-tools
+# - Runs all per-tool uninstallers
+# - Additionally removes system packages for perf / llvm-mca / skopeo (best-effort)
 set -e
 
 INSTALL_PREFIX="/opt/arm-migration-tools"
@@ -17,7 +20,116 @@ if [[ "$SCRIPT_DIR" == "$INSTALL_PREFIX"* && "$SCRIPT_DIR" != /tmp* ]]; then
   exit 0
 fi
 
-# Remove installed tools directory
+# --- helpers -----------------------------------------------------------------
+detect_pkg_mgr() {
+  if command -v apt-get >/dev/null 2>&1; then
+    PKG_MGR="apt"
+  elif command -v dnf >/dev/null 2>&1; then
+    PKG_MGR="dnf"
+  elif command -v yum >/dev/null 2>&1; then
+    PKG_MGR="yum"
+  else
+    PKG_MGR=""
+  fi
+}
+
+apt_remove_list() {
+  # Remove each pkg if installed; ignore errors. Then autoremove.
+  local pkgs=("$@")
+  local to_remove=()
+  for p in "${pkgs[@]}"; do
+    if dpkg -l | awk '{print $2}' | grep -qx "$p"; then
+      to_remove+=("$p")
+    fi
+  done
+  if (( ${#to_remove[@]} )); then
+    echo "[INFO] Removing with apt: ${to_remove[*]}"
+    sudo apt-get -y remove --purge "${to_remove[@]}" || true
+  fi
+  # Also strip any versioned llvm-*tools packages if present
+  local llvm_tools
+  llvm_tools=$(dpkg -l | awk '/^ii\s+llvm-.*-tools\s/ {print $2}')
+  if [[ -n "$llvm_tools" ]]; then
+    echo "[INFO] Removing versioned LLVM tools: $llvm_tools"
+    sudo apt-get -y remove --purge $llvm_tools || true
+  fi
+  # Perf kernel-specific helpers we might have installed
+  local kver kset=()
+  kver="$(uname -r)"
+  for extra in "linux-tools-${kver}" "linux-cloud-tools-${kver}"; do
+    if dpkg -l | awk '{print $2}' | grep -qx "$extra"; then
+      kset+=("$extra")
+    fi
+  done
+  if (( ${#kset[@]} )); then
+    echo "[INFO] Removing kernel-specific perf helpers: ${kset[*]}"
+    sudo apt-get -y remove --purge "${kset[@]}" || true
+  fi
+  # Generic meta packages, if present
+  for meta in linux-tools-generic linux-cloud-tools-generic; do
+    if dpkg -l | awk '{print $2}' | grep -qx "$meta"; then
+      echo "[INFO] Removing meta-package: $meta"
+      sudo apt-get -y remove --purge "$meta" || true
+    fi
+  done
+  # Clean up leaf deps
+  sudo apt-get -y autoremove --purge || true
+}
+
+rpm_remove_list() {
+  # For dnf/yum. Remove if installed.
+  local pkgs=("$@")
+  local present=()
+  for p in "${pkgs[@]}"; do
+    if rpm -q "$p" >/dev/null 2>&1; then
+      present+=("$p")
+    fi
+  done
+  if (( ${#present[@]} )); then
+    echo "[INFO] Removing with ${PKG_MGR}: ${present[*]}"
+    if [[ "$PKG_MGR" == "dnf" ]]; then
+      sudo dnf -y remove "${present[@]}" || true
+    else
+      sudo yum -y remove "${present[@]}" || true
+    fi
+  fi
+}
+
+remove_system_packages() {
+  detect_pkg_mgr
+  if [[ -z "$PKG_MGR" ]]; then
+    echo "[WARN] No supported package manager found; skipping system package removals."
+    return 0
+  fi
+
+  # Try to detect distro family for better hints
+  local ID=""
+  if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+  fi
+
+  echo "[INFO] Removing system packages related to perf / llvm-mca / skopeo (best-effort)..."
+
+  case "$PKG_MGR" in
+    apt)
+      # What we may have installed on Ubuntu:
+      #  - skopeo
+      #  - llvm (and versioned llvm-*-tools that carry llvm-mca)
+      #  - linux-tools-* and linux-cloud-tools-* for perf
+      apt_remove_list skopeo llvm
+      ;;
+    dnf|yum)
+      # What we may have installed on AL2023 / RHEL / Fedora / CentOS:
+      #  - skopeo, perf, llvm, llvm-tools, clang
+      rpm_remove_list skopeo perf llvm llvm-tools clang
+      ;;
+  esac
+}
+
+# --- removal flow -------------------------------------------------------------
+
+# Remove installed tools directory first
 if [ -d "$INSTALL_PREFIX" ]; then
   echo "[INFO] Removing $INSTALL_PREFIX..."
   sudo rm -rf "$INSTALL_PREFIX"
@@ -25,45 +137,34 @@ else
   echo "[INFO] $INSTALL_PREFIX does not exist. Skipping."
 fi
 
-# Uninstall sysreport
-bash "$(dirname "$0")/uninstall_sysreport.sh"
-# Uninstall kubearchinspect
-bash "$(dirname "$0")/uninstall_kubearchinspect.sh"
-# Uninstall arm-migration-tools-test.sh
-bash "$(dirname "$0")/uninstall_test_wrapper.sh"
-# Uninstall check-image wrapper
-bash "$(dirname "$0")/uninstall_check_image.sh"
+# Call per-tool uninstall scripts (ignore failures to stay idempotent)
+UNINSTALL_SCRIPTS=(
+  uninstall_sysreport.sh
+  uninstall_kubearchinspect.sh
+  uninstall_test_wrapper.sh
+  uninstall_check_image.sh
+  uninstall_skopeo.sh
+  uninstall_perf.sh
+  uninstall_mca.sh
+  uninstall_aperf.sh
+  uninstall_bolt.sh
+  uninstall_processwatch.sh
+  uninstall_topdown_tool.sh
+  uninstall_papi.sh
+  uninstall_migrate_ease.sh
+  uninstall_migrate_ease_wrappers.sh
+  uninstall_porting_advisor.sh
+)
 
-# Uninstall Skopeo
-bash "$(dirname "$0")/uninstall_skopeo.sh"
-# Uninstall Perf
-bash "$(dirname "$0")/uninstall_perf.sh"
+for script in "${UNINSTALL_SCRIPTS[@]}"; do
+  if [[ -f "$(dirname "$0")/$script" ]]; then
+    bash "$(dirname "$0")/$script" || true
+  else
+    echo "[WARN] Missing uninstall script: $script"
+  fi
+done
 
-# Uninstall MCA (llvm-mca)
-bash "$(dirname "$0")/uninstall_mca.sh"
-# Uninstall Aperf
-bash "$(dirname "$0")/uninstall_aperf.sh"
-
-# Remove BOLT
-bash "$(dirname "$0")/uninstall_bolt.sh"
-
-# Remove Process Watch
-bash "$(dirname "$0")/uninstall_processwatch.sh"
-
-# Remove Topdown Tool
-bash "$(dirname "$0")/uninstall_topdown_tool.sh"
-
-# Uninstall PAPI
-bash "$(dirname "$0")/uninstall_papi.sh"
-
-# Uninstall Migrate Ease
-bash "$(dirname "$0")/uninstall_migrate_ease.sh"
-
-# Uninstall Migrate Ease wrappers
-bash "$(dirname "$0")/uninstall_migrate_ease_wrappers.sh"
-
-# Uninstall Porting Advisor
-bash "$(dirname "$0")/uninstall_porting_advisor.sh"
-
+# Actively remove system packages we might have added
+remove_system_packages
 
 echo "[INFO] Uninstallation complete."

--- a/scripts/uninstall_perf.sh
+++ b/scripts/uninstall_perf.sh
@@ -1,17 +1,86 @@
-#!/bin/bash
-# Uninstall Perf package
-set -e
-if [ -f /etc/os-release ]; then
+#!/usr/bin/env bash
+# Uninstall Perf (best-effort, idempotent)
+set -euo pipefail
+
+remove_wrapper() {
+  if [[ -L /usr/local/bin/perf || -f /usr/local/bin/perf ]]; then
+    echo "[INFO] Removing /usr/local/bin/perf wrapper/symlink..."
+    sudo rm -f /usr/local/bin/perf || true
+  fi
+}
+
+apt_uninstall_perf() {
+  echo "[INFO] Removing Perf with apt (best-effort)..."
+  local kver; kver="$(uname -r)"
+
+  # Kernel-specific helpers we may have installed
+  local maybe_kpkgs=(
+    "linux-tools-${kver}"
+    "linux-cloud-tools-${kver}"
+  )
+
+  # Common meta packages
+  local maybe_meta=(linux-tools-generic linux-cloud-tools-generic linux-tools-common linux-cloud-tools-common)
+
+  # Any versioned linux-tools we may have pulled in (e.g., linux-tools-6.8.0-78)
+  local versioned_tools
+  versioned_tools=$(dpkg -l | awk '/^ii\s+linux-.*tools/{print $2}') || true
+
+  # Remove present packages
+  local to_remove=()
+  for p in "${maybe_kpkgs[@]}" "${maybe_meta[@]}"; do
+    dpkg -l | awk '{print $2}' | grep -qx "$p" && to_remove+=("$p")
+  done
+  if [[ -n "${versioned_tools:-}" ]]; then
+    to_remove+=($versioned_tools)
+  fi
+
+  if (( ${#to_remove[@]} )); then
+    echo "[INFO] apt purge: ${to_remove[*]}"
+    sudo apt-get -y purge "${to_remove[@]}" || true
+  fi
+
+  # Clean up leaf deps
+  sudo apt-get -y autoremove --purge || true
+}
+
+rpm_uninstall_perf() {
+  # Amazon Linux / RHEL / Fedora / CentOS
+  local mgr=""
+  command -v dnf >/dev/null 2>&1 && mgr="dnf"
+  command -v yum >/dev/null 2>&1 && [[ -z $mgr ]] && mgr="yum"
+
+  if [[ -z $mgr ]]; then
+    echo "[WARN] No dnf/yum found; skipping RPM perf removal."
+    return 0
+  fi
+
+  echo "[INFO] Removing Perf with ${mgr} (best-effort)..."
+  sudo "$mgr" -y remove perf || true
+}
+
+main() {
+  remove_wrapper
+
+  if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
     . /etc/os-release
-    if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
-        echo "[INFO] Removing Perf with apt..."
-        sudo apt-get remove -y linux-tools-generic linux-tools-$(uname -r) 
-    elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
-        echo "[INFO] Removing Perf with dnf/yum..."
-        sudo dnf remove -y perf || sudo yum remove -y perf
-    else
-        echo "[ERROR] Unsupported OS: $ID. Please remove Perf manually."
-    fi
-else
-    echo "[ERROR] Cannot detect OS. Please remove Perf manually."
-fi
+    case "${ID:-}" in
+      ubuntu|debian)
+        apt_uninstall_perf
+        ;;
+      amzn|rhel|centos|fedora)
+        rpm_uninstall_perf
+        ;;
+      *)
+        echo "[WARN] Unsupported OS: ${ID:-unknown}. Skipping package removal."
+        ;;
+    esac
+  else
+    echo "[WARN] Cannot detect OS. Skipping package removal."
+  fi
+
+  echo "[INFO] Perf uninstall step complete."
+}
+
+main "$@"

--- a/scripts/uninstall_perf.sh
+++ b/scripts/uninstall_perf.sh
@@ -1,86 +1,23 @@
 #!/usr/bin/env bash
-# Uninstall Perf (best-effort, idempotent)
 set -euo pipefail
 
-remove_wrapper() {
-  if [[ -L /usr/local/bin/perf || -f /usr/local/bin/perf ]]; then
-    echo "[INFO] Removing /usr/local/bin/perf wrapper/symlink..."
-    sudo rm -f /usr/local/bin/perf || true
-  fi
-}
+[ "$(id -u)" -eq 0 ] || exec sudo -E -- "$0" "$@"
 
-apt_uninstall_perf() {
-  echo "[INFO] Removing Perf with apt (best-effort)..."
-  local kver; kver="$(uname -r)"
+KVER="$(uname -r)"
 
-  # Kernel-specific helpers we may have installed
-  local maybe_kpkgs=(
-    "linux-tools-${kver}"
-    "linux-cloud-tools-${kver}"
-  )
+# Remove alternatives and our links
+update-alternatives --remove-all perf 2>/dev/null || true
+rm -f /usr/local/bin/perf \
+      "/usr/lib/linux-tools-${KVER}/perf" \
+      "/usr/lib/linux-tools/${KVER}/perf" || true
 
-  # Common meta packages
-  local maybe_meta=(linux-tools-generic linux-cloud-tools-generic linux-tools-common linux-cloud-tools-common)
+# Leave distro package files intact, but you can uncomment to remove on Ubuntu:
+# apt-get remove -y linux-tools-common linux-tools-generic "linux-tools-${KVER}" "linux-cloud-tools-${KVER}" || true
 
-  # Any versioned linux-tools we may have pulled in (e.g., linux-tools-6.8.0-78)
-  local versioned_tools
-  versioned_tools=$(dpkg -l | awk '/^ii\s+linux-.*tools/{print $2}') || true
+# Remove our sysctl if we created it
+if [ -f /etc/sysctl.d/99-perf.conf ] && grep -q 'arm-linux-migration-tools' /etc/sysctl.d/99-perf.conf; then
+  rm -f /etc/sysctl.d/99-perf.conf
+  sysctl --system >/dev/null || true
+fi
 
-  # Remove present packages
-  local to_remove=()
-  for p in "${maybe_kpkgs[@]}" "${maybe_meta[@]}"; do
-    dpkg -l | awk '{print $2}' | grep -qx "$p" && to_remove+=("$p")
-  done
-  if [[ -n "${versioned_tools:-}" ]]; then
-    to_remove+=($versioned_tools)
-  fi
-
-  if (( ${#to_remove[@]} )); then
-    echo "[INFO] apt purge: ${to_remove[*]}"
-    sudo apt-get -y purge "${to_remove[@]}" || true
-  fi
-
-  # Clean up leaf deps
-  sudo apt-get -y autoremove --purge || true
-}
-
-rpm_uninstall_perf() {
-  # Amazon Linux / RHEL / Fedora / CentOS
-  local mgr=""
-  command -v dnf >/dev/null 2>&1 && mgr="dnf"
-  command -v yum >/dev/null 2>&1 && [[ -z $mgr ]] && mgr="yum"
-
-  if [[ -z $mgr ]]; then
-    echo "[WARN] No dnf/yum found; skipping RPM perf removal."
-    return 0
-  fi
-
-  echo "[INFO] Removing Perf with ${mgr} (best-effort)..."
-  sudo "$mgr" -y remove perf || true
-}
-
-main() {
-  remove_wrapper
-
-  if [[ -f /etc/os-release ]]; then
-    # shellcheck disable=SC1091
-    . /etc/os-release
-    case "${ID:-}" in
-      ubuntu|debian)
-        apt_uninstall_perf
-        ;;
-      amzn|rhel|centos|fedora)
-        rpm_uninstall_perf
-        ;;
-      *)
-        echo "[WARN] Unsupported OS: ${ID:-unknown}. Skipping package removal."
-        ;;
-    esac
-  else
-    echo "[WARN] Cannot detect OS. Skipping package removal."
-  fi
-
-  echo "[INFO] Perf uninstall step complete."
-}
-
-main "$@"
+echo "[INFO] perf un-wired. Wrapper (if any) may remain."


### PR DESCRIPTION
This PR finalizes the installation/uninstallation flow of the Arm Linux Migration Tools by ensuring consistent behavior across Ubuntu 22.04 / 24.04 and Amazon Linux 2023.

Verified full install >> uninstall >> reinstall >> revalidate sequence works on:
	•	Ubuntu 22.04 & 24.04 (aarch64)
	•	Amazon Linux 2023 (aarch64)
	•	All 13 tools install and run successfully

Note:
-  On Amazon Linux 2023, skopeo is intentionally skipped (not yet supported via package manager)
-  porting-advisor wrapper expects Python >= 3.10. On Ubuntu this is satisfied (3.12+); on AL2023 (Python 3.9 by default), wrapper installs but running requires Python 3.11

 This PR makes install/uninstall idempotent, reliable, and consistent across supported distros.

Sample Test can be done as:
Clone repo >>Build locally >>  sudo scripts/install.sh >> sudo scripts/install.sh(Idempotent)
sudo scripts/uninstall.sh >> Re-install 

Verify Tool Versions:
```
for t in sysreport kubearchinspect check-image topdown-tool \
           migrate-ease-cpp aperf llvm-bolt perf llvm-mca papi_avail \
           processwatch porting-advisor skopeo; do
  echo "=== $t ==="
  command -v $t && ($t --version 2>/dev/null || $t -h 2>/dev/null | head -n1)
done
```
