### PR TITLE
Arm Linux Migration Tools: Add full wrapper support, improve test coverage, and clarify perf/migrate-ease usage

### DIFF
--- a/scripts/arm-migration-tools-test.sh
+++ b/scripts/arm-migration-tools-test.sh
@@ -1,31 +1,132 @@
 #!/bin/bash
-# Test all Arm migration tools and log output
+# Comprehensive test for Arm Linux Migration Tools
+# - Safe, offline checks (no network pulls)
+# - Emits PASS/FAIL/SKIP with reasons
+# - Exit non-zero on any FAIL
 
+set -uo pipefail
 LOG_FILE="$(pwd)/arm-migration-tools-test.log"
+SUMMARY_FILE="$(pwd)/arm-migration-tools-test.summary.tsv"
+VENV="/opt/arm-migration-tools/venv/bin/python"
+
 echo "[INFO] Testing Arm migration tools..." | tee "$LOG_FILE"
+echo -e "tool\tstatus\tnote" > "$SUMMARY_FILE"
+
+pass(){ echo -e "$1\tPASS\t$2" >>"$SUMMARY_FILE"; }
+skip(){ echo -e "$1\tSKIP\t$2" >>"$SUMMARY_FILE"; }
+fail(){ echo -e "$1\tFAIL\t$2" >>"$SUMMARY_FILE"; }
 
 run_and_log() {
-  TOOL="$1"
-  CMD="$2"
-  echo "[INFO] Running $TOOL..." | tee -a "$LOG_FILE"
-  echo -e "\n===== $TOOL =====" >> "$LOG_FILE"
-  eval "$CMD" >> "$LOG_FILE" 2>&1
+  local tool="$1" cmd="$2"
+  echo "[INFO] Running $tool..." | tee -a "$LOG_FILE"
+  echo -e "\n===== $tool =====" >> "$LOG_FILE"
+  bash -c "$cmd" >> "$LOG_FILE" 2>&1
+  return $?
 }
 
-run_and_log "Sysreport" "sysreport --help"
-run_and_log "Skopeo" "skopeo --help"
-run_and_log "MCA (llvm-mca)" "llvm-mca --help"
-run_and_log "Topdown Tool" "topdown-tool --help"
-run_and_log "KubeArchInspect" "kubearchinspect --help"
-run_and_log "KubeArchInspect" "kubearchinspect --help"
-run_and_log "Migrate Ease" "migrate-ease-cpp --help"
-run_and_log "Aperf" "aperf --help"
-run_and_log "BOLT" "llvm-bolt --help"
-run_and_log "BOLT (perf2bolt)" "perf2bolt --help"
-run_and_log "PAPI" "papi_avail -h"
-run_and_log "Perf" "perf --help"
-run_and_log "Process Watch" "processwatch -h"
-run_and_log "Check Image" "check-image -h"
-run_and_log "Porting Advisor" "porting-advisor --help"
+#CLI tools 
+cli_check() {
+  local name="$1" bin="$2" smoke="$3" note_ok="${4:-}"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    skip "$name" "not installed"
+    return 0
+  fi
+  if run_and_log "$name" "$smoke"; then
+    pass "$name" "${note_ok:-ok}"
+  else
+    fail "$name" "installed but smoke test failed"
+  fi
+}
+
+# Core tools
+cli_check "Sysreport"        "sysreport"        "sysreport --help"
+cli_check "Skopeo"           "skopeo"           "skopeo --version"
+cli_check "MCA (llvm-mca)"   "llvm-mca"         "llvm-mca --version"
+cli_check "Topdown Tool"     "topdown-tool"     "topdown-tool --help"
+cli_check "KubeArchInspect"  "kubearchinspect"  "kubearchinspect --help"
+
+# Migrate-ease wrappers (all 6)
+cli_check "Migrate Ease (cpp)"    "migrate-ease-cpp"    "migrate-ease-cpp --help"
+cli_check "Migrate Ease (python)" "migrate-ease-python" "migrate-ease-python --help"
+cli_check "Migrate Ease (go)"     "migrate-ease-go"     "migrate-ease-go --help"
+cli_check "Migrate Ease (js)"     "migrate-ease-js"     "migrate-ease-js --help"
+cli_check "Migrate Ease (java)"   "migrate-ease-java"   "migrate-ease-java --help"
+if command -v docker >/dev/null 2>&1 || command -v podman >/dev/null 2>&1; then
+  cli_check "Migrate Ease (docker)" "migrate-ease-docker" "migrate-ease-docker --help"
+else
+  skip "Migrate Ease (docker)" "no docker/podman detected"
+fi
+
+# Other binaries
+cli_check "Aperf"             "aperf"           "aperf --version"
+cli_check "BOLT (llvm-bolt)"  "llvm-bolt"       "llvm-bolt --version"
+cli_check "BOLT (perf2bolt)"  "perf2bolt"       "perf2bolt --version"
+cli_check "PAPI"              "papi_avail"      "papi_avail -h || papi_avail --help || true"
+# cli_check "Process Watch" "processwatch" "processwatch -h || processwatch -v || true"
+if command -v processwatch >/dev/null 2>&1; then
+  echo "[INFO] Running Process Watch..." | tee -a "$LOG_FILE"
+  echo -e "\n===== Process Watch =====" >> "$LOG_FILE"
+  OUT="$(processwatch -h 2>&1 || true; processwatch -v 2>&1 || true)"
+  echo "$OUT" >> "$LOG_FILE"
+  if echo "$OUT" | grep -qiE 'usage: processwatch|^Version:'; then
+    pass "Process Watch" "ok"
+  else
+    fail "Process Watch" "installed but smoke test failed"
+  fi
+else
+  skip "Process Watch" "not installed"
+fi
+cli_check "Check Image"       "check-image"     "check-image -h"
+cli_check "Porting Advisor"   "porting-advisor" "porting-advisor --version"
+
+# Perf: meaningful smoke (counters), not just --help
+if command -v perf >/dev/null 2>&1; then
+  if run_and_log "Perf (stat smoke)" "perf stat -e task-clock sleep 0.1"; then
+    pass "Perf" "counters available ($(perf --version | head -n1))"
+  else
+    # Typical on Docker-on-mac/Colima (XNU host) or locked-down kernels
+    skip "Perf" "binary present but counters unsupported on this kernel"
+  fi
+else
+  skip "Perf" "not installed"
+fi
+
+#Python deps sanity in venv
+if [ -x "$VENV" ]; then
+  echo -e "\n===== Python venv imports =====" >> "$LOG_FILE"
+  if "$VENV" - <<'PY' >>"$LOG_FILE" 2>&1; then
+import sys
+import importlib.util as iu
+
+mods = ["requests", "magic"]  # shared deps we rely on
+missing = [m for m in mods if iu.find_spec(m) is None]
+ok = True
+try:
+    import magic
+    # Confirm libmagic is actually loadable/usable
+    magic.Magic(mime=True)
+except Exception as e:
+    ok = False
+    print("python-magic error:", e)
+print("MISSING_MODS:", ",".join(missing))
+sys.exit(0 if ok and not missing else 1)
+PY
+    pass "Python venv deps" "requests and python-magic OK"
+  else
+    fail "Python venv deps" "requests/magic import failed (see log)"
+  fi
+else
+  skip "Python venv deps" "venv python not found"
+fi
+
+# ---------- Summary ----------
+echo
+column -t -s $'\t' "$SUMMARY_FILE" | tee -a "$LOG_FILE"
+
+# Exit non-zero if any FAIL
+if grep -q $'\tFAIL\t' "$SUMMARY_FILE"; then
+  echo "[INFO] One or more checks FAILED. See $LOG_FILE"
+  exit 1
+fi
 
 echo "[INFO] Testing complete. Log saved to $LOG_FILE."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -505,13 +505,25 @@ summary_check() {
     echo "$name: SKIPPED"
   fi
 }
+summary_perf() {
+  if command -v perf >/dev/null 2>&1; then
+    if perf stat -e task-clock sleep 0.1 >/dev/null 2>&1; then
+      echo "perf: OK ($(perf --version 2>&1 | head -n1))"
+    else
+      echo "perf: FAIL (binary found but counters unavailable; check kernel/perms)"
+    fi
+  else
+    # Common when running inside Docker-on-mac/Colima (XNU host kernel)
+    echo "perf: SKIPPED (unsupported kernel or not installed)"
+  fi
+}
 
 summary_check "sysreport" sysreport
 summary_check "kubearchinspect" kubearchinspect
 summary_check "migrate-ease-cpp" migrate-ease-cpp
 summary_check "aperf" aperf
 summary_check "llvm-bolt" llvm-bolt
-summary_check "perf" perf
+summary_perf
 summary_check "llvm-mca" llvm-mca
 summary_check "papi" papi_avail
 summary_check "processwatch" processwatch

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,10 @@
 # Supports both local installation (with tarball) and remote installation (via curl)
 set -e
 
+# keep it in AMT_VERSION; then clear VERSION so OS sourcing can't overwrite.
+AMT_VERSION="${VERSION:-}"
+unset VERSION
+
 # Require root; auto-escalate if possible
 if [ "$EUID" -ne 0 ]; then
   if command -v sudo >/dev/null 2>&1; then
@@ -27,10 +31,7 @@ flock -n 200 || {
   echo "[ERROR] Another install.sh is already running. Exiting."
   exit 1
 }
-# ------------------------------
-# Cross-distro dependency install
-# Supports: Ubuntu (apt), Amazon Linux 2023 (dnf), Amazon Linux 2 (yum)
-# ------------------------------
+
 detect_pkg_mgr() {
   if command -v apt-get >/dev/null 2>&1; then
     PKG_MGR="apt"
@@ -57,7 +58,7 @@ ensure_deps() {
       sudo apt-get install -y "${COMMON_PKGS[@]}" "${APT_PKGS[@]}"
       ;;
     dnf|yum)
-      # gcc/g++/make ≈ build-essential
+      # gcc/g++/make build-essential
       YUM_PKGS=(gcc gcc-c++ make)
       echo "[INFO] Installing prerequisites via $PKG_MGR..."
       # If curl-minimal already exists, don't try to install curl
@@ -65,7 +66,6 @@ ensure_deps() {
         echo "[INFO] curl-minimal present, skipping curl package."
         COMMON_PKGS=(wget git python3 python3-pip)
       fi
-
       sudo $PKG_MGR -y install "${COMMON_PKGS[@]}" "${YUM_PKGS[@]}"
       sudo $PKG_MGR -y install python3-venv 2>/dev/null || true
       sudo $PKG_MGR -y install python3-virtualenv 2>/dev/null || true
@@ -77,12 +77,81 @@ ensure_deps() {
     exit 1
   fi
 }
+ensure_core_runtime() {
+  if [ -f /etc/os-release ]; then 
+    . /etc/os-release
+  fi
+  case "${ID:-}" in
+    ubuntu|debian)
+      sudo apt-get update -y
+      sudo apt-get install -y --no-install-recommends \
+        ca-certificates file tar xz-utils unzip jq procps || true
+      ;;
+    amzn|rhel|centos|fedora)
+      if command -v dnf >/dev/null 2>&1; then
+        sudo dnf -y install ca-certificates file tar xz unzip jq procps-ng || true
+      else
+        sudo yum -y install ca-certificates file tar xz unzip jq procps-ng || true
+      fi
+      ;;
+  esac
+}
 
+# Best-effort runtime dep for migrate-ease-python (python-magic > libmagic)
+ensure_libmagic() {
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+      ubuntu|debian)
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends file libmagic1 || true
+        ;;
+      amzn|rhel|centos|fedora)
+        if command -v dnf >/dev/null 2>&1; then
+          sudo dnf -y install file-libs || true
+        else
+          sudo yum -y install file-libs || true
+        fi
+        ;;
+      *) : ;;
+    esac
+  fi
+}
+# Optional container runtime installer
+# Controlled via INSTALL_CONTAINER_RUNTIME=1
+
+maybe_install_container_runtime() {
+  if [ "${INSTALL_CONTAINER_RUNTIME:-0}" = "1" ]; then
+    echo "[INFO] INSTALL_CONTAINER_RUNTIME=1 set, attempting to install Docker/Podman..."
+    if [ -f /etc/os-release ]; then
+      . /etc/os-release
+      case "$ID" in
+        ubuntu|debian)
+          sudo apt-get update -y
+          sudo apt-get install -y docker.io || sudo apt-get install -y podman || true
+          ;;
+        amzn|rhel|centos|fedora)
+          if command -v dnf >/dev/null 2>&1; then
+            sudo dnf -y install docker moby-engine || sudo dnf -y install podman || true
+          else
+            sudo yum -y install docker || sudo yum -y install podman || true
+          fi
+          ;;
+        *)
+          echo "[WARN] Unsupported OS for automatic Docker install; please install manually."
+          ;;
+      esac
+    fi
+  else
+    echo "[INFO] INSTALL_CONTAINER_RUNTIME not set; skipping runtime install."
+  fi
+}
 INSTALL_PREFIX="/opt/arm-migration-tools"
 GITHUB_REPO="arm/arm-linux-migration-tools"
 STAMP_FILE="$INSTALL_PREFIX/.installed_version"
 
 ensure_deps
+ensure_core_runtime
 
 # Detect if this is a remote installation (no local tarball files)
 REMOTE_INSTALL=false
@@ -91,72 +160,55 @@ if [ ! -f "$(dirname "$0")/../README.md" ] && [ -z "$(ls arm-migration-tools-v*.
 fi
 
 # Handle remote installation
-
 if [ "$REMOTE_INSTALL" = true ]; then
   echo "[INFO] Remote installation detected. Downloading latest release..."
-
-  # Check for required tools
   if ! command -v curl >/dev/null 2>&1; then
     echo "[ERROR] curl is required for remote installation but not found." >&2
     exit 1
   fi
-
-  # Fetch latest release information
   LATEST_RELEASE_URL="https://api.github.com/repos/$GITHUB_REPO/releases/latest"
   echo "[INFO] Fetching latest release information..."
-
   LATEST_TAG=$(curl -s "$LATEST_RELEASE_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | tr -d 'v')
   if [ -z "$LATEST_TAG" ]; then
     echo "[ERROR] Failed to fetch latest release tag" >&2
     exit 1
   fi
 
-  VERSION="$LATEST_TAG"
-  if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$VERSION" ]; then
-    echo "[INFO] arm-migration-tools v$VERSION already installed at $INSTALL_PREFIX, skipping download/extract."
+  AMT_VERSION="$LATEST_TAG"
+  if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$AMT_VERSION" ]; then
+    echo "[INFO] arm-migration-tools v$AMT_VERSION already installed at $INSTALL_PREFIX, skipping download/extract."
     SCRIPTS_DIR="$INSTALL_PREFIX/scripts"
   else
     DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$LATEST_TAG/arm-migration-tools-v$LATEST_TAG.tar.gz"
     echo "[INFO] Downloading version v$LATEST_TAG from $DOWNLOAD_URL..."
 
-    # Create temporary directory and download
     TEMP_DIR=$(mktemp -d)
     cd "$TEMP_DIR"
-
     if ! curl -L -f -o "arm-migration-tools.tar.gz" "$DOWNLOAD_URL"; then
       echo "[ERROR] Failed to download release tarball" >&2
       exit 1
     fi
 
-    # Extract to install prefix
     echo "[INFO] Extracting to $INSTALL_PREFIX..."
     sudo mkdir -p "$INSTALL_PREFIX"
     sudo tar xzf "arm-migration-tools.tar.gz" -C "$INSTALL_PREFIX"
-    echo "$VERSION" | sudo tee "$STAMP_FILE" >/dev/null   # record the installed version
-
-    # Change to the extracted scripts directory
+    echo "$AMT_VERSION" | sudo tee "$STAMP_FILE" >/dev/null
     SCRIPTS_DIR="$INSTALL_PREFIX/scripts"
-
-    # Clean up temp directory
     cd /
     rm -rf "$TEMP_DIR"
   fi
-
 else
-  # Handle local installation
   echo "[INFO] Local installation detected."
-  
-  # Set the version here (default to newest if not set)
-  if [ -z "$VERSION" ]; then
+  if [ -z "${AMT_VERSION:-}" ]; then
     LATEST_TAR=$(ls arm-migration-tools-v*.tar.gz 2>/dev/null | sort -V | tail -n 1)
     if [ -z "$LATEST_TAR" ]; then
       echo "[ERROR] No arm-migration-tools-v*.tar.gz files found." >&2
       exit 1
     fi
     TAR_FILE="$LATEST_TAR"
-    VERSION=$(echo "$TAR_FILE" | sed -E 's/.*-v([0-9]+)\.tar\.gz/\1/')
+    AMT_VERSION=$(echo "$TAR_FILE" | sed -E 's/.*-v([0-9]+)\.tar\.gz/\1/')
   else
-    TAR_FILE="arm-migration-tools-v$VERSION.tar.gz"
+    TAR_FILE="arm-migration-tools-v$AMT_VERSION.tar.gz"
   fi
 
   if [ ! -f "$TAR_FILE" ]; then
@@ -164,25 +216,71 @@ else
     exit 1
   fi
 
-  if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$VERSION" ]; then
-    echo "[INFO] arm-migration-tools v$VERSION already installed at $INSTALL_PREFIX, skipping extract."
+  if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$AMT_VERSION" ]; then
+    echo "[INFO] arm-migration-tools v$AMT_VERSION already installed at $INSTALL_PREFIX, skipping extract."
   else
     echo "[INFO] Extracting $TAR_FILE to $INSTALL_PREFIX..."
     sudo mkdir -p "$INSTALL_PREFIX"
     sudo tar xzf "$TAR_FILE" -C "$INSTALL_PREFIX"
-    echo "$VERSION" | sudo tee "$STAMP_FILE" >/dev/null
+    echo "$AMT_VERSION" | sudo tee "$STAMP_FILE" >/dev/null
   fi
 
-  # Use relative path for local installation
   SCRIPTS_DIR="$(dirname "$0")"
 fi
 
 # Create additional wrappers for remote installation
 if [ "$REMOTE_INSTALL" = true ]; then
-  # Install arm-migration-tools-test.sh to /usr/local/bin
   if [ -f "$INSTALL_PREFIX/scripts/arm-migration-tools-test.sh" ]; then
-      sudo cp "$INSTALL_PREFIX/scripts/arm-migration-tools-test.sh" /usr/local/bin/arm-migration-tools-test.sh
-      sudo chmod +x /usr/local/bin/arm-migration-tools-test.sh
+    sudo cp "$INSTALL_PREFIX/scripts/arm-migration-tools-test.sh" /usr/local/bin/arm-migration-tools-test.sh
+    sudo chmod +x /usr/local/bin/arm-migration-tools-test.sh
+  fi
+fi
+
+
+# Python venv early (before any wrappers that use it)
+VENV_PATH="$INSTALL_PREFIX/venv"
+PYTHON3=$(command -v python3 || true)
+if [ -z "$PYTHON3" ]; then
+  echo "[ERROR] python3 not found. Please install Python 3."
+  exit 1
+fi
+if [ ! -d "$VENV_PATH" ]; then
+  echo "[INFO] Creating Python venv at $VENV_PATH..."
+  if ! "$PYTHON3" -m venv "$VENV_PATH" 2>/dev/null; then
+    echo "[INFO] python -m venv unavailable; falling back to virtualenv..."
+    "$PYTHON3" -m pip install --upgrade pip virtualenv
+    "$PYTHON3" -m virtualenv "$VENV_PATH"
+  fi
+fi
+# Upgrade pip
+sudo "$VENV_PATH/bin/pip" install --upgrade pip
+
+# Install requirements only if requirements.txt changed
+REQ_FILE="$INSTALL_PREFIX/requirements.txt"
+REQ_HASH_FILE="$VENV_PATH/.reqs_hash"
+if [ -f "$REQ_FILE" ]; then
+  NEW_HASH=$(sha256sum "$REQ_FILE" | awk '{print $1}')
+  OLD_HASH=$(cat "$REQ_HASH_FILE" 2>/dev/null || true)
+  if [ "$NEW_HASH" != "$OLD_HASH" ]; then
+    echo "[INFO] Installing/Updating Python requirements..."
+    sudo "$VENV_PATH/bin/pip" install -r "$REQ_FILE"
+    echo "$NEW_HASH" | sudo tee "$REQ_HASH_FILE" >/dev/null
+  else
+    echo "[INFO] Python requirements already up-to-date, skipping."
+  fi
+fi
+if ! "$VENV_PATH/bin/python" -c "import requests" 2>/dev/null; then
+  echo "[INFO] Installing missing Python dependency: requests"
+  sudo "$VENV_PATH/bin/pip" install requests
+fi
+
+# Install Topdown Tool in editable mode in the venv (idempotent)
+if [ -d "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool" ]; then
+  if "$VENV_PATH/bin/python" -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('topdown_tool') else 1)" 2>/dev/null; then
+    echo "[INFO] topdown_tool already importable in venv, skipping -e install."
+  else
+    echo "[INFO] Installing topdown_tool into venv (-e)..."
+    sudo "$VENV_PATH/bin/pip" install -e "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool"
   fi
 fi
 
@@ -198,6 +296,7 @@ if [ -f "$SCRIPTS_DIR/install_sysreport.sh" ]; then
     bash "$SCRIPTS_DIR/install_sysreport.sh"
   fi
 fi
+
 # Install skopeo
 if [ -f "$SCRIPTS_DIR/install_skopeo.sh" ]; then
   if command -v skopeo >/dev/null 2>&1; then
@@ -218,7 +317,7 @@ if [ -f "$SCRIPTS_DIR/install_kubearchinspect.sh" ]; then
   fi
 fi
 
-# ---- Perf: always ensure it's installed & wired correctly ----
+# Perf: always ensure it's installed & wired correctly
 if [ -f "$SCRIPTS_DIR/install_perf.sh" ]; then
   echo "[INFO] Ensuring Perf is installed and wired..."
   # Tune kernel.perf_event_paranoid unless explicitly disabled by caller
@@ -275,8 +374,9 @@ if [ -f "$SCRIPTS_DIR/install_papi.sh" ]; then
   fi
 fi
 
-# Install Migrate Ease
+# Install Migrate Ease (package + wrappers)
 if [ -f "$SCRIPTS_DIR/install_migrate_ease.sh" ]; then
+  ensure_libmagic
   if python3 -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('migrate_ease') else 1)" 2>/dev/null; then
     echo "[INFO] Migrate Ease (Python pkg) already installed, skipping."
   else
@@ -287,7 +387,26 @@ fi
 
 # Install Migrate Ease wrappers
 if [ -f "$SCRIPTS_DIR/install_migrate_ease_wrappers.sh" ]; then
-  if command -v migrate-ease-cpp >/dev/null 2>&1; then
+  maybe_install_container_runtime
+
+  has_container="no"
+  if command -v docker >/dev/null 2>&1 || command -v podman >/dev/null 2>&1 || [ "${FORCE_DOCKER_WRAPPER:-0}" = "1" ]; then
+    has_container="yes"
+  fi
+
+  # base set everyone must have
+  base_ok=true
+  for w in migrate-ease-cpp migrate-ease-python migrate-ease-go migrate-ease-js migrate-ease-java; do
+    command -v "$w" >/dev/null 2>&1 || { base_ok=false; break; }
+  done
+
+  # docker wrapper only if runtime is present/forced
+  docker_ok=true
+  if [ "$has_container" = "yes" ]; then
+    command -v migrate-ease-docker >/dev/null 2>&1 || docker_ok=false
+  fi
+
+  if $base_ok && $docker_ok; then
     echo "[INFO] Migrate Ease wrappers already installed, skipping."
   else
     echo "[INFO] Installing Migrate Ease wrappers..."
@@ -325,57 +444,10 @@ if [ -f "$SCRIPTS_DIR/install_topdown_tool.sh" ]; then
   fi
 fi
 
-# Set up Python venv and install requirements
-VENV_PATH="$INSTALL_PREFIX/venv"
-PYTHON3=$(command -v python3)
-if [ -z "$PYTHON3" ]; then
-  echo "[ERROR] python3 not found. Please install Python 3."
-  exit 1
-fi
-if [ ! -d "$VENV_PATH" ]; then
-  echo "[INFO] Creating Python venv at $VENV_PATH..."
-  if ! "$PYTHON3" -m venv "$VENV_PATH" 2>/dev/null; then
-    echo "[INFO] python -m venv unavailable; falling back to virtualenv..."
-    "$PYTHON3" -m pip install --upgrade pip virtualenv
-    "$PYTHON3" -m virtualenv "$VENV_PATH"
-  fi
-fi
-
-
-# Upgrade pip and install requirements
-sudo "$VENV_PATH/bin/pip" install --upgrade pip
-
-# Install requirements only if requirements.txt changed
-REQ_FILE="$INSTALL_PREFIX/requirements.txt"
-REQ_HASH_FILE="$VENV_PATH/.reqs_hash"
-
-if [ -f "$REQ_FILE" ]; then
-  NEW_HASH=$(sha256sum "$REQ_FILE" | awk '{print $1}')
-  OLD_HASH=$(cat "$REQ_HASH_FILE" 2>/dev/null || true)
-
-  if [ "$NEW_HASH" != "$OLD_HASH" ]; then
-    echo "[INFO] Installing/Updating Python requirements..."
-    sudo "$VENV_PATH/bin/pip" install -r "$REQ_FILE"
-    echo "$NEW_HASH" | sudo tee "$REQ_HASH_FILE" >/dev/null
-  else
-    echo "[INFO] Python requirements already up-to-date, skipping."
-  fi
-fi
-
-# Install Topdown Tool in editable mode in the venv (idempotent)
-if [ -d "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool" ]; then
-  if "$VENV_PATH/bin/python" -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('topdown_tool') else 1)" 2>/dev/null; then
-    echo "[INFO] topdown_tool already importable in venv, skipping -e install."
-  else
-    echo "[INFO] Installing topdown_tool into venv (-e)..."
-    sudo "$VENV_PATH/bin/pip" install -e "$INSTALL_PREFIX/telemetry-solution/tools/topdown_tool"
-  fi
-fi
-
 # Record tool versions in a single file (after install)
 VERSIONS_FILE="$INSTALL_PREFIX/tool-versions.txt"
-echo "Sysreport: $VERSION" | sudo tee "$VERSIONS_FILE" > /dev/null
-echo "Check Image: $VERSION" | sudo tee -a "$VERSIONS_FILE" > /dev/null
+echo "Sysreport: $AMT_VERSION" | sudo tee "$VERSIONS_FILE" > /dev/null
+echo "Check Image: $AMT_VERSION" | sudo tee -a "$VERSIONS_FILE" > /dev/null
 if command -v skopeo >/dev/null 2>&1; then
   skopeo --version 2>&1 | head -n1 | awk '{print "Skopeo: "$0}' | sudo tee -a "$VERSIONS_FILE" > /dev/null
 fi
@@ -417,8 +489,7 @@ cat <<EOM
 Or use the provided wrappers in /usr/local/bin for each tool (recommended).
 EOM
 
-
-# ---- Compact install summary ----
+# INSTALL SUMMARY
 echo "[SUMMARY]"
 
 summary_check() {
@@ -427,12 +498,6 @@ summary_check() {
     case "$cmd" in
       kubearchinspect)
         echo "$name: OK (Check how ready your Kubernetes cluster is to run on Arm.)" ;;
-      porting-advisor)
-        if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)'; then
-          echo "$name: OK ($("$cmd" --version 2>&1 | head -n1))"
-        else
-          echo "$name: INSTALLED (Python ≥3.10 required to run)"
-        fi ;;
       *)
         echo "$name: OK ($("$cmd" --version 2>&1 | head -n1 || $cmd --help 2>&1 | head -n1))" ;;
     esac
@@ -454,3 +519,9 @@ summary_check "check-image" check-image
 summary_check "porting-advisor" porting-advisor
 summary_check "skopeo" skopeo
 summary_check "topdown-tool" topdown-tool
+
+if command -v docker >/dev/null 2>&1 || command -v podman >/dev/null 2>&1 || [ "${FORCE_DOCKER_WRAPPER:-0}" = "1" ]; then
+  summary_check "migrate-ease-docker" migrate-ease-docker
+else
+  echo "migrate-ease-docker: SKIPPED (no docker/podman detected)"
+fi

--- a/scripts/install_aperf.sh
+++ b/scripts/install_aperf.sh
@@ -3,21 +3,28 @@
 set -e
 
 INSTALL_PREFIX="/opt/arm-migration-tools"
-# The binary should be in the aperf directory after build
-APERF_SRC="$INSTALL_PREFIX/aperf/aperf"
 APERF_BIN="$INSTALL_PREFIX/aperf/aperf"
 
-if [ ! -f "$APERF_SRC" ]; then
-  echo "[ERROR] Aperf binary not found at $APERF_SRC."
-  exit 1
+if [ ! -f "$APERF_BIN" ]; then
+  if [ -f "$INSTALL_PREFIX/aperf-bin/aperf" ]; then
+    sudo mkdir -p "$INSTALL_PREFIX/aperf"
+    sudo cp -f "$INSTALL_PREFIX/aperf-bin/aperf" "$APERF_BIN"
+  elif [ -f "aperf/aperf" ]; then
+    sudo mkdir -p "$INSTALL_PREFIX/aperf"
+    sudo cp -f "aperf/aperf" "$APERF_BIN"
+  else
+    echo "[ERROR] Aperf binary not found (looked in $APERF_BIN and common fallbacks)."
+    echo "        Please run the Aperf build or stage the binary."
+    exit 1
+  fi
 fi
 
-sudo mkdir -p "$INSTALL_PREFIX/aperf"
-# The binary is already in the correct location, just ensure it's executable
 sudo chmod +x "$APERF_BIN"
 
-# Create symlink in /usr/local/bin
+# Create/update symlink in /usr/local/bin
 APERF_WRAPPER="/usr/local/bin/aperf"
 sudo ln -sf "$APERF_BIN" "$APERF_WRAPPER"
+
+"$APERF_WRAPPER" --version >/dev/null 2>&1 || true
 
 echo "[INFO] Aperf installed. Run 'aperf --version' to test."

--- a/scripts/install_bolt.sh
+++ b/scripts/install_bolt.sh
@@ -8,16 +8,19 @@ BOLT_DST="$INSTALL_PREFIX/bolt-tools"
 
 if [ ! -d "$BOLT_DST" ]; then
   if [ ! -d "$BOLT_SRC" ]; then
-    echo "[ERROR] BOLT directory not found. Please run build_bolt.sh first."
+    echo "[ERROR] BOLT directory not found. Please run build_bolt.sh first or stage 'bolt-tools/'."
     exit 1
   fi
-
   sudo mkdir -p "$INSTALL_PREFIX"
   sudo cp -a "$BOLT_SRC" "$BOLT_DST"
 fi
 
-# Create symlinks in /usr/local/bin
+sudo chmod +x "$BOLT_DST/llvm-bolt" "$BOLT_DST/perf2bolt" 2>/dev/null || true
+
 sudo ln -sf "$BOLT_DST/llvm-bolt" /usr/local/bin/llvm-bolt
 sudo ln -sf "$BOLT_DST/perf2bolt" /usr/local/bin/perf2bolt
+
+llvm-bolt --version >/dev/null 2>&1 || true
+perf2bolt --help  >/dev/null 2>&1 || true
 
 echo "[INFO] BOLT installed. Run 'llvm-bolt --version' to test."

--- a/scripts/install_check_image.sh
+++ b/scripts/install_check_image.sh
@@ -3,13 +3,22 @@
 set -e
 
 CHECK_IMAGE_WRAPPER="/usr/local/bin/check-image"
-cat << 'EOF' | sudo tee $CHECK_IMAGE_WRAPPER > /dev/null
+# Use venv python if present; otherwise fall back to system python3
+cat << 'EOF' | sudo tee "$CHECK_IMAGE_WRAPPER" > /dev/null
 #!/bin/bash
-# Forward -h/--help directly to Python script to avoid network calls
-if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-  exec python3 /opt/arm-migration-tools/src/check-image.py "$@"
-else
-  exec python3 /opt/arm-migration-tools/src/check-image.py "$@"
+PY_VENV="/opt/arm-migration-tools/venv/bin/python"
+PY_SYS="$(command -v python3 || true)"
+PY="${PY_VENV}"
+[ -x "$PY_VENV" ] || PY="${PY_SYS}"
+
+# If no arguments are passed, default to -h to avoid traceback
+if [ $# -eq 0 ]; then
+  set -- -h
 fi
+
+exec "$PY" /opt/arm-migration-tools/src/check-image.py "$@"
 EOF
-sudo chmod +x $CHECK_IMAGE_WRAPPER
+
+sudo chmod +x "$CHECK_IMAGE_WRAPPER"
+
+echo "[INFO] check-image wrapper installed. Run 'check-image -h' to test."

--- a/scripts/install_kubearchinspect.sh
+++ b/scripts/install_kubearchinspect.sh
@@ -11,11 +11,15 @@ if [ ! -f "$KAI_BIN" ]; then
   exit 1
 fi
 
+sudo chmod +x "$KAI_BIN"
+
 # Create wrapper in /usr/local/bin
-cat << EOF | sudo tee $KAI_WRAPPER > /dev/null
+cat << EOF | sudo tee "$KAI_WRAPPER" > /dev/null
 #!/bin/bash
-exec $KAI_BIN "\$@"
+exec "$KAI_BIN" "\$@"
 EOF
-sudo chmod +x $KAI_WRAPPER
+sudo chmod +x "$KAI_WRAPPER"
+
+"$KAI_WRAPPER" version >/dev/null 2>&1 || true
 
 echo "[INFO] KubeArchInspect installed. Run 'kubearchinspect --help' to test."

--- a/scripts/install_mca.sh
+++ b/scripts/install_mca.sh
@@ -3,53 +3,52 @@
 # Supports: Ubuntu/Debian, Amazon Linux 2023, Fedora/RHEL/CentOS
 set -e
 
-# Helper: check if llvm-mca is actually present
 have_mca() { command -v llvm-mca >/dev/null 2>&1; }
 
 if [ -f /etc/os-release ]; then
-    . /etc/os-release
+  . /etc/os-release
 
-    if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
-        echo "[INFO] Installing llvm-mca with apt..."
-        sudo apt-get update
-        sudo apt-get install -y llvm
+  if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
+    echo "[INFO] Installing llvm/llvm-mca with apt..."
+    sudo apt-get update -y
+    sudo apt-get install -y llvm || true
 
-        if have_mca; then
-            echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."
-        else
-            echo "[WARN] llvm installed but 'llvm-mca' not found on PATH."
-            echo "[WARN] On some Ubuntu versions llvm-mca is in versioned packages (e.g. llvm-14)."
-            echo "[WARN] Try: sudo apt-get install -y 'llvm-*-tools'"
-        fi
-        exit 0
-
-    elif [[ $ID == "amzn" ]]; then
-        echo "[INFO] Installing llvm on Amazon Linux 2023..."
-        # AL2023 uses dnf
-        sudo dnf -y install llvm || true
-        sudo dnf -y install llvm-tools || true
-        sudo dnf -y install clang || true
-
-        if have_mca; then
-            echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."
-        else
-            echo "[WARN] 'llvm-mca' not available in Amazon Linux 2023 repos."
-            echo "[WARN] Skipping llvm-mca. You can install it manually (from LLVM releases or source)."
-        fi
-        exit 0
-
-    elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
-        echo "[INFO] Installing llvm-mca with dnf/yum..."
-        sudo dnf -y install llvm || sudo yum -y install llvm
-        sudo dnf -y install llvm-tools || true
-        echo "[INFO] MCA (llvm-mca) installation attempt finished. Run 'llvm-mca --help' to test."
-        exit 0
-
-    else
-        echo "[ERROR] Unsupported OS: $ID. Please install llvm-mca manually."
-        exit 0
+    if ! have_mca; then
+      # Best-effort to pull a versioned tools pkg that carries llvm-mca
+      CANDIDATE=$(apt-cache search -n '^llvm-[0-9]+-tools$' | awk '{print $1}' | sort -V | tail -n1)
+      if [ -n "$CANDIDATE" ]; then
+        sudo apt-get install -y "$CANDIDATE" || true
+      fi
     fi
+
+    if have_mca; then
+      echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."
+    else
+      echo "[WARN] llvm installed but 'llvm-mca' not found on PATH."
+      echo "[WARN] Try: sudo apt-get install -y 'llvm-*-tools' for your distro's LLVM version."
+    fi
+
+  elif [[ $ID == "amzn" ]]; then
+    echo "[INFO] Installing llvm on Amazon Linux..."
+    sudo dnf -y install llvm || true
+    sudo dnf -y install llvm-tools || true
+    sudo dnf -y install clang || true
+
+    if have_mca; then
+      echo "[INFO] MCA (llvm-mca) installation complete. Run 'llvm-mca --help' to test."
+    else
+      echo "[WARN] 'llvm-mca' not available in Amazon Linux repos; skipping."
+    fi
+
+  elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
+    echo "[INFO] Installing llvm/llvm-mca with dnf/yum..."
+    (sudo dnf -y install llvm || sudo yum -y install llvm) || true
+    sudo dnf -y install llvm-tools || true
+    echo "[INFO] MCA install attempt complete. Run 'llvm-mca --help' to test."
+
+  else
+    echo "[ERROR] Unsupported OS: $ID. Please install llvm-mca manually."
+  fi
 else
-    echo "[ERROR] Cannot detect OS. Please install llvm-mca manually."
-    exit 0
+  echo "[ERROR] Cannot detect OS. Please install llvm-mca manually."
 fi

--- a/scripts/install_migrate_ease.sh
+++ b/scripts/install_migrate_ease.sh
@@ -1,14 +1,31 @@
 #!/bin/bash
 # Install script for Migrate Ease
-set -e
+set -euo pipefail
 
 INSTALL_PREFIX="/opt/arm-migration-tools"
-VENV_PATH="$INSTALL_PREFIX/venv"
 MIGRATE_EASE_DIR="$INSTALL_PREFIX/migrate-ease"
 
 # Copy migrate-ease repo to install prefix if not already present
 if [ ! -d "$MIGRATE_EASE_DIR" ]; then
+  sudo mkdir -p "$INSTALL_PREFIX"
   sudo cp -a migrate-ease "$MIGRATE_EASE_DIR"
 fi
 
-echo "[INFO] Migrate Ease installed. Activate the venv and run with: python -m migrate_ease --help"
+if [ -r /etc/os-release ]; then . /etc/os-release; fi
+case "${ID:-}" in
+  ubuntu|debian)
+    sudo apt-get update -y
+    sudo apt-get install -y --no-install-recommends file libmagic1 || true
+    ;;
+  amzn|rhel|centos|fedora)
+    if command -v dnf >/dev/null 2>&1; then
+      sudo dnf install -y file-libs || true
+    else
+      sudo yum install -y file-libs || true
+    fi
+    ;;
+  *) : ;;
+esac
+
+echo "[INFO] Migrate Ease installed at $MIGRATE_EASE_DIR."
+echo "[INFO] Use wrappers (recommended) or: python -m migrate_ease --help"

--- a/scripts/install_migrate_ease_wrappers.sh
+++ b/scripts/install_migrate_ease_wrappers.sh
@@ -1,28 +1,36 @@
 #!/bin/bash
 # Create wrappers for Migrate Ease subcommands
-set -e
+set -euo pipefail
 
 INSTALL_PREFIX="/opt/arm-migration-tools"
 VENV_PATH="$INSTALL_PREFIX/venv"
 MIGRATE_EASE_DIR="$INSTALL_PREFIX/migrate-ease"
 
 create_wrapper() {
-  WRAPPER_NAME="$1"
-  MODULE_NAME="$2"
-  WRAPPER_PATH="/usr/local/bin/$WRAPPER_NAME"
-  cat << EOF | sudo tee $WRAPPER_PATH > /dev/null
+  local WRAPPER_NAME="$1"
+  local MODULE_NAME="$2"
+  local WRAPPER_PATH="/usr/local/bin/$WRAPPER_NAME"
+  cat << EOF | sudo tee "$WRAPPER_PATH" > /dev/null
 #!/bin/bash
 cd "$MIGRATE_EASE_DIR"
 exec "$VENV_PATH/bin/python" -m $MODULE_NAME "\$@"
 EOF
-  sudo chmod +x $WRAPPER_PATH
+  sudo chmod +x "$WRAPPER_PATH"
 }
 
-create_wrapper migrate-ease-cpp cpp
-create_wrapper migrate-ease-go go
-create_wrapper migrate-ease-docker docker
-create_wrapper migrate-ease-js js
-create_wrapper migrate-ease-java java
+# Always create the language wrappers
+create_wrapper migrate-ease-cpp    cpp
+create_wrapper migrate-ease-go     go
+create_wrapper migrate-ease-js     js
+create_wrapper migrate-ease-java   java
 create_wrapper migrate-ease-python python
 
-echo "[INFO] Migrate Ease wrappers installed: migrate-ease-cpp, migrate-ease-go, migrate-ease-docker, migrate-ease-js, migrate-ease-java, migrate-ease-python."
+# Create the docker wrapper only if docker/podman is available, unless forced
+if command -v docker >/dev/null 2>&1 || command -v podman >/dev/null 2>&1 || [ "${FORCE_DOCKER_WRAPPER:-0}" = "1" ]; then
+  create_wrapper migrate-ease-docker docker
+  echo "[INFO] Migrate Ease docker wrapper installed."
+else
+  echo "[INFO] No docker/podman detected; skipping migrate-ease-docker wrapper."
+fi
+
+echo "[INFO] Migrate Ease wrappers installed (per environment)."

--- a/scripts/install_papi.sh
+++ b/scripts/install_papi.sh
@@ -12,11 +12,9 @@ if [ ! -d "$PAPI_STAGED" ]; then
 fi
 
 echo "[INFO] Installing PAPI to /usr/local..."
+sudo mkdir -p /usr/local
 sudo cp -r "$PAPI_STAGED"/* /usr/local/
 
-# Optionally, add PAPI version to tool-versions.txt if run from main install.sh
-if [ -f "$PAPI_STAGED/PAPI.version" ]; then
-  echo "PAPI: $(cat "$PAPI_STAGED/PAPI.version")" | sudo tee -a "$INSTALL_PREFIX/tool-versions.txt" > /dev/null
-fi
+command -v papi_avail >/dev/null 2>&1 && papi_avail >/dev/null 2>&1 || true
 
 echo "[INFO] PAPI installed. Run 'papi_avail' to test."

--- a/scripts/install_porting_advisor.sh
+++ b/scripts/install_porting_advisor.sh
@@ -5,8 +5,10 @@ set -e
 INSTALL_PREFIX="/opt/arm-migration-tools"
 VENV_PATH="$INSTALL_PREFIX/venv"
 PORTING_ADVISOR_WRAPPER="/usr/local/bin/porting-advisor"
-cat << EOF | sudo tee $PORTING_ADVISOR_WRAPPER > /dev/null
+
+cat << EOF | sudo tee "$PORTING_ADVISOR_WRAPPER" > /dev/null
 #!/bin/bash
 exec "$VENV_PATH/bin/python" "$INSTALL_PREFIX/porting-advisor-for-graviton/src/porting-advisor.py" "\$@"
 EOF
-sudo chmod +x $PORTING_ADVISOR_WRAPPER
+
+sudo chmod +x "$PORTING_ADVISOR_WRAPPER"

--- a/scripts/install_processwatch.sh
+++ b/scripts/install_processwatch.sh
@@ -10,7 +10,6 @@ ensure_built() {
   if [ -x "$PW_SRC" ]; then
     return
   fi
-  # Try to build
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   if [ ! -x "$SCRIPT_DIR/build_processwatch.sh" ]; then
     echo "[ERROR] $SCRIPT_DIR/build_processwatch.sh not found or not executable." >&2
@@ -27,4 +26,8 @@ ensure_built
 sudo chmod +x "$PW_SRC"
 sudo ln -sf "$PW_SRC" "$PW_WRAPPER"
 
-echo "[INFO] Process Watch installed. Run 'processwatch -h' to test."
+if "$PW_SRC" --help >/dev/null 2>&1; then
+  echo "[INFO] Process Watch installed. Run 'processwatch --help' to test."
+else
+  echo "[WARN] Process Watch binary present but '--help' failed. May require root or kernel features."
+fi

--- a/scripts/install_skopeo.sh
+++ b/scripts/install_skopeo.sh
@@ -2,30 +2,28 @@
 # Install Skopeo using the system package manager
 set -e
 
-# Detect OS and install Skopeo
 if [ -f /etc/os-release ]; then
-    . /etc/os-release
-    if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
-        echo "[INFO] Installing Skopeo with apt..."
-        sudo apt-get update
-        sudo apt-get install -y skopeo
-
-    elif [[ $ID == "amzn" ]]; then
-        # Temporary decision: skip Skopeo on Amazon Linux; continue without failing
-        echo "[WARN] Amazon Linux detected (amzn). Skipping Skopeo install for now."
-        exit 0
-
-    elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
-        echo "[INFO] Installing Skopeo with yum..."
-        sudo yum install -y skopeo || sudo dnf install -y skopeo
-
-    else
-        echo "[WARN] Unsupported OS: $ID. Please install Skopeo manually."
-        exit 1
-    fi
-else
-    echo "[ERROR] Cannot detect OS. Please install Skopeo manually."
+  . /etc/os-release
+  if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
+    echo "[INFO] Installing Skopeo with apt..."
+    sudo apt-get update -y
+    sudo apt-get install -y skopeo
+  elif [[ $ID == "amzn" ]]; then
+  #known warning: skip on Amazon Linux for now
+    echo "[WARN] Amazon Linux detected (amzn). Skipping Skopeo install for now."
+    exit 0
+  elif [[ $ID == "fedora" || $ID == "rhel" || $ID == "centos" ]]; then
+    echo "[INFO] Installing Skopeo with yum/dnf..."
+    (sudo yum install -y skopeo || sudo dnf install -y skopeo)
+  else
+    echo "[WARN] Unsupported OS: $ID. Please install Skopeo manually."
     exit 1
+  fi
+else
+  echo "[ERROR] Cannot detect OS. Please install Skopeo manually."
+  exit 1
 fi
 
+# Smoke
+skopeo --help >/dev/null 2>&1 || true
 echo "[INFO] Skopeo installation complete. Run 'skopeo --help' to test."

--- a/scripts/install_sysreport.sh
+++ b/scripts/install_sysreport.sh
@@ -7,28 +7,32 @@ INSTALL_PREFIX="/opt/arm-migration-tools"
 # Extract tarball if present (optional)
 if [ -f sysreport.tar.gz ]; then
   echo "[INFO] Extracting sysreport.tar.gz..."
-  mkdir -p "$INSTALL_PREFIX"
-  tar xzf sysreport.tar.gz -C "$INSTALL_PREFIX"
+  sudo mkdir -p "$INSTALL_PREFIX"
+  sudo tar xzf sysreport.tar.gz -C "$INSTALL_PREFIX"
 fi
 
 # If source directory exists, copy it
 if [ -d sysreport ]; then
   echo "[INFO] Copying sysreport source to $INSTALL_PREFIX..."
-  mkdir -p "$INSTALL_PREFIX"
-  cp -r sysreport "$INSTALL_PREFIX/"
+  sudo mkdir -p "$INSTALL_PREFIX"
+  sudo cp -r sysreport "$INSTALL_PREFIX/"
 fi
+
+# Wrapper
+SYSREPORT_WRAPPER="/usr/local/bin/sysreport"
+cat << 'EOF' | sudo tee "$SYSREPORT_WRAPPER" > /dev/null
+#!/bin/bash
+# Prefer venv python if available
+PY_VENV="/opt/arm-migration-tools/venv/bin/python"
+PY_SYS="$(command -v python3 || true)"
+PY="${PY_VENV}"
+[ -x "$PY_VENV" ] || PY="${PY_SYS}"
+
+cd /opt/arm-migration-tools/sysreport/src || exit 1
+exec "$PY" sysreport.py "$@"
+EOF
+sudo chmod +x "$SYSREPORT_WRAPPER"
+
+sysreport --help >/dev/null 2>&1 || true
 
 echo "[INFO] Sysreport installed. Run 'sysreport --help' to test."
-
-# Install wrapper for sysreport
-SYSREPORT_WRAPPER="/usr/local/bin/sysreport"
-cat << 'EOF' | sudo tee $SYSREPORT_WRAPPER > /dev/null
-#!/bin/bash
-cd /opt/arm-migration-tools/sysreport/src
-if [ $# -eq 0 ]; then
-  exec python3 sysreport.py
-else
-  exec python3 sysreport.py "$@"
-fi
-EOF
-sudo chmod +x $SYSREPORT_WRAPPER

--- a/scripts/install_topdown_tool.sh
+++ b/scripts/install_topdown_tool.sh
@@ -5,8 +5,14 @@ set -e
 INSTALL_PREFIX="/opt/arm-migration-tools"
 VENV_PATH="$INSTALL_PREFIX/venv"
 TOPDOWN_WRAPPER="/usr/local/bin/topdown-tool"
-cat << EOF | sudo tee $TOPDOWN_WRAPPER > /dev/null
+
+cat << EOF | sudo tee "$TOPDOWN_WRAPPER" > /dev/null
 #!/bin/bash
 exec "$VENV_PATH/bin/topdown-tool" "\$@"
 EOF
-sudo chmod +x $TOPDOWN_WRAPPER
+sudo chmod +x "$TOPDOWN_WRAPPER"
+
+# Smoke
+topdown-tool -h >/dev/null 2>&1 || true
+
+echo "[INFO] Topdown Tool wrapper installed at $TOPDOWN_WRAPPER"

--- a/scripts/uninstall_bolt.sh
+++ b/scripts/uninstall_bolt.sh
@@ -6,10 +6,10 @@ INSTALL_PREFIX="/opt/arm-migration-tools"
 BOLT_DST="$INSTALL_PREFIX/bolt-tools"
 
 # Remove symlinks
-if [ -L /usr/local/bin/llvm-bolt ]; then
+if [ -e /usr/local/bin/llvm-bolt ]; then
   sudo rm -f /usr/local/bin/llvm-bolt
 fi
-if [ -L /usr/local/bin/perf2bolt ]; then
+if [ -e /usr/local/bin/perf2bolt ]; then
   sudo rm -f /usr/local/bin/perf2bolt
 fi
 

--- a/scripts/uninstall_check_image.sh
+++ b/scripts/uninstall_check_image.sh
@@ -2,7 +2,7 @@
 # Uninstall check-image wrapper
 set -e
 CHECK_IMAGE_WRAPPER="/usr/local/bin/check-image"
-if [ -f "$CHECK_IMAGE_WRAPPER" ]; then
+if [ -e "$CHECK_IMAGE_WRAPPER" ]; then
   echo "[INFO] Removing $CHECK_IMAGE_WRAPPER..."
   sudo rm -f "$CHECK_IMAGE_WRAPPER"
 fi

--- a/scripts/uninstall_kubearchinspect.sh
+++ b/scripts/uninstall_kubearchinspect.sh
@@ -2,7 +2,7 @@
 # Uninstall kubearchinspect and its wrapper
 set -e
 KAI_WRAPPER="/usr/local/bin/kubearchinspect"
-if [ -f "$KAI_WRAPPER" ]; then
+if [ -e "$KAI_WRAPPER" ]; then
   echo "[INFO] Removing $KAI_WRAPPER..."
   sudo rm -f "$KAI_WRAPPER"
 fi

--- a/scripts/uninstall_mca.sh
+++ b/scripts/uninstall_mca.sh
@@ -2,6 +2,6 @@
 # Uninstall MCA (llvm-mca) and its symlink
 set -e
 
-if [ -L /usr/local/bin/llvm-mca ]; then
+if [ -e /usr/local/bin/llvm-mca ]; then
   sudo rm -f /usr/local/bin/llvm-mca
 fi

--- a/scripts/uninstall_processwatch.sh
+++ b/scripts/uninstall_processwatch.sh
@@ -6,7 +6,7 @@ INSTALL_PREFIX="/opt/arm-migration-tools"
 PW_WRAPPER="/usr/local/bin/processwatch"
 PW_BIN="$INSTALL_PREFIX/processwatch/processwatch"
 
-if [ -L "$PW_WRAPPER" ]; then
+if [ -e "$PW_WRAPPER" ]; then
   sudo rm -f "$PW_WRAPPER"
 fi
 if [ -f "$PW_BIN" ]; then

--- a/scripts/uninstall_sysreport.sh
+++ b/scripts/uninstall_sysreport.sh
@@ -2,7 +2,7 @@
 # Uninstall sysreport and its wrapper
 set -e
 SYSREPORT_WRAPPER="/usr/local/bin/sysreport"
-if [ -f "$SYSREPORT_WRAPPER" ]; then
+if [ -e "$SYSREPORT_WRAPPER" ]; then
   echo "[INFO] Removing $SYSREPORT_WRAPPER..."
   sudo rm -f "$SYSREPORT_WRAPPER"
 fi


### PR DESCRIPTION
Ensures all 13 tools (sysreport, skopeo, llvm-mca, topdown-tool, kube-arch-inspect, migrate-ease [5 + docker], aperf, BOLT, PAPI, perf, processwatch, check-image, porting-advisor) install/uninstall cleanly.
Adds robust handling for migrate-ease language wrappers:
cpp, python, go, js, java → always installed
docker → installed only if Docker/Podman is available
Adds Python dependency check for requests and python-magic, auto-installed if missing.
Ensures libmagic system dependency is pulled in where required (avoids ImportError).

**Test Script (arm-migration-tools-test.sh)**
	•	New comprehensive test harness outputs:
	              -  arm-migration-tools-test.log (full logs)
		      -  arm-migration-tools-test.summary.tsv (tool / status / note)
	•	Each tool reports one of:
	        •	PASS – installed and working
	        •	SKIP – intentionally unsupported (e.g., perf on mac/Colima; migrate-ease-docker without Docker)
	        •	FAIL – found but smoke test failed
	•	Perf now uses a real stat smoke test; reports SKIP when counters unavailable (common on macOS/Colima).
	•	Process Watch test tolerates return codes from -h/-v, ensuring usage/version output is accepted as PASS.

**Documentation (README.md):**

	•	Clarifies system requirements (Arm64, supported OS, macOS/Colima caveats).
	•	Adds explicit migrate-ease CLI vs upstream section:
	        •	Upstream uses python3 -m {scanner}.
	        •	This package provides unified wrappers (migrate-ease-cpp, etc.) in /usr/local/bin for consistency across languages.
	•	Adds note that perf is kernel-dependent and will be SKIPPED in Colima/macOS environments.
	•	Adds troubleshooting note for libmagic missing inside minimal containers, with commands to install manually.
	•	Documents test script outputs (PASS/SKIP/FAIL) to understand results clearly.

Thanks & Open for suggestions !!