### PR TITLE
Add x86_64 support: multi-arch builds 

### DIFF
--- a/scripts/build_aperf.sh
+++ b/scripts/build_aperf.sh
@@ -3,7 +3,16 @@
 set -e
 
 APERF_VERSION="v0.1.15-alpha"
-APERF_TAR="aperf-${APERF_VERSION}-aarch64.tar.gz"
+# APERF_TAR="aperf-${APERF_VERSION}-aarch64.tar.gz"
+# APERF_URL="https://github.com/aws/aperf/releases/download/${APERF_VERSION}/${APERF_TAR}"
+ARCH=$(uname -m)
+case "$ARCH" in
+  aarch64|arm64) AP_ARCH="aarch64" ;;
+  x86_64|amd64)  AP_ARCH="x86_64" ;;
+  *) echo "[ERROR] Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+APERF_TAR="aperf-${APERF_VERSION}-${AP_ARCH}.tar.gz"
 APERF_URL="https://github.com/aws/aperf/releases/download/${APERF_VERSION}/${APERF_TAR}"
 APERF_DIR="aperf-bin"
 

--- a/scripts/build_bolt.sh
+++ b/scripts/build_bolt.sh
@@ -3,7 +3,22 @@
 set -e
 
 BOLT_VERSION="19.1.7"
-BOLT_TAR="clang+llvm-${BOLT_VERSION}-aarch64-linux-gnu.tar.xz"
+# BOLT_TAR="clang+llvm-${BOLT_VERSION}-aarch64-linux-gnu.tar.xz"
+# BOLT_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${BOLT_VERSION}/${BOLT_TAR}"
+ARCH=$(uname -m)
+case "$ARCH" in
+  aarch64|arm64)
+    BOLT_TAR="clang+llvm-${BOLT_VERSION}-aarch64-linux-gnu.tar.xz"
+    ;;
+  x86_64|amd64)
+    BOLT_TAR="LLVM-${BOLT_VERSION}-Linux-X64.tar.xz"
+    ;;
+  *)
+    echo "[ERROR] Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
 BOLT_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${BOLT_VERSION}/${BOLT_TAR}"
 BOLT_DIR="bolt-bin"
 

--- a/scripts/build_kubearchinspect.sh
+++ b/scripts/build_kubearchinspect.sh
@@ -3,7 +3,14 @@
 set -e
 
 KAI_VERSION="0.7.0"
-KAI_TAR="kubearchinspect_Linux_arm64.tar.gz"
+ARCH=$(uname -m)
+case "$ARCH" in
+  aarch64|arm64) KAI_ARCH="arm64" ;;
+  x86_64|amd64)  KAI_ARCH="x86_64" ;;
+  *) echo "[ERROR] Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+KAI_TAR="kubearchinspect_Linux_${KAI_ARCH}.tar.gz"
 KAI_URL="https://github.com/ArmDeveloperEcosystem/kubearchinspect/releases/download/v${KAI_VERSION}/${KAI_TAR}"
 KAI_DIR="kubearchinspect"
 

--- a/scripts/build_papi.sh
+++ b/scripts/build_papi.sh
@@ -8,15 +8,14 @@ SRC_DIR="$BUILD_ROOT/papi-src"
 PAPI_REPO="https://github.com/icl-utk-edu/papi.git"
 PAPI_CLONE_DIR="$SRC_DIR/papi"
 PACKAGE_ROOT="$(pwd)"
+PAPI_TAG="papi-7-2-0-t"   
 
-mkdir -p "$BUILD_ROOT"
-mkdir -p "$INSTALL_DIR"
-mkdir -p "$SRC_DIR"
+mkdir -p "$BUILD_ROOT" "$INSTALL_DIR" "$SRC_DIR"
 
 # Clone PAPI repo if not already present
 if [ ! -d "$PAPI_CLONE_DIR" ]; then
-  echo "[INFO] Cloning PAPI repo..."
-  git clone --depth 1 "$PAPI_REPO" "$PAPI_CLONE_DIR"
+  echo "[INFO] Cloning PAPI repo at tag $PAPI_TAG..."
+  git clone --branch "$PAPI_TAG" --depth 1 "$PAPI_REPO" "$PAPI_CLONE_DIR"
 fi
 
 cd "$PAPI_CLONE_DIR/src"
@@ -25,12 +24,12 @@ cd "$PAPI_CLONE_DIR/src"
 ./configure --prefix="$INSTALL_DIR"
 
 # Build and install
-make -j$(nproc)
+make -j"$(nproc)"
 make install
 
-# Record commit hash as version
+# Record version
 cd "$PAPI_CLONE_DIR"
-PAPI_VERSION=$(git rev-parse --short HEAD)
+PAPI_VERSION=$(git describe --tags --always)
 echo "$PAPI_VERSION" > "$INSTALL_DIR/PAPI.version"
 
 # Copy staged PAPI install into package root
@@ -38,4 +37,4 @@ if [ -d "$INSTALL_DIR" ]; then
   cp -a "$INSTALL_DIR" "$PACKAGE_ROOT/"
 fi
 
-echo "[INFO] PAPI built and staged at $INSTALL_DIR (commit $PAPI_VERSION)."
+echo "[INFO] PAPI built and staged at $INSTALL_DIR (version $PAPI_VERSION)."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,12 +18,15 @@ if [ "$EUID" -ne 0 ]; then
   fi
 fi
 
-# Check for Arm Linux (aarch64)
+# Check for Arm Linux (aarch64)/x86_64 host
 ARCH=$(uname -m)
-if [ "$ARCH" != "aarch64" ]; then
-  echo "[ERROR] This installer is intended for Arm 64-bit (aarch64) Linux systems. Detected: $ARCH" >&2
-  exit 1
-fi
+case "$ARCH" in
+  aarch64|arm64)   ARCH_NORM="arm64"   ;;
+  x86_64|amd64)    ARCH_NORM="x86_64" ;;
+  *) echo "[WARN] Unrecognized architecture '$ARCH'; defaulting to arm64 tarball." >&2
+     ARCH_NORM="arm64"
+     ;;
+esac
 
 LOCKFILE="/tmp/arm-migration-tools.lock"
 exec 200>"$LOCKFILE"
@@ -179,7 +182,7 @@ if [ "$REMOTE_INSTALL" = true ]; then
     echo "[INFO] arm-migration-tools v$AMT_VERSION already installed at $INSTALL_PREFIX, skipping download/extract."
     SCRIPTS_DIR="$INSTALL_PREFIX/scripts"
   else
-    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$LATEST_TAG/arm-migration-tools-v$LATEST_TAG.tar.gz"
+    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$LATEST_TAG/arm-migration-tools-v${LATEST_TAG}-${ARCH_NORM}.tar.gz"
     echo "[INFO] Downloading version v$LATEST_TAG from $DOWNLOAD_URL..."
 
     TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
This PR adds x86 support alongside arm64 for building and installing Arm Linux Migration Tools.

Changes Made: Build scripts, Install scripts

Release Packaging: 
To publish a release, build tarballs on both arches:
```
./scripts/build.sh 1 && mv arm-migration-tools-v1.tar.gz arm-migration-tools-v1-arm64.tar.gz
./scripts/build.sh 1 && mv arm-migration-tools-v1.tar.gz arm-migration-tools-v1-x86_64.tar.gz
```
Upload both to GitHub Releases; `install.sh` will select automatically.
